### PR TITLE
Added Dutch UI language and fixed typos

### DIFF
--- a/src/Vocup/Controls/FileTreeView.nl.resx
+++ b/src/Vocup/Controls/FileTreeView.nl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="BrowseButton.ToolTip" xml:space="preserve">
-    <value>Standaard map voor taalbestanden kiezen</value>
+    <value>Standaard map voor woordenboeken kiezen</value>
   </data>
 </root>

--- a/src/Vocup/Controls/FileTreeView.nl.resx
+++ b/src/Vocup/Controls/FileTreeView.nl.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BrowseButton.ToolTip" xml:space="preserve">
+    <value>Standaard map voor taalbestanden kiezen</value>
+  </data>
+</root>

--- a/src/Vocup/Controls/StatisticsPanel.nl.resx
+++ b/src/Vocup/Controls/StatisticsPanel.nl.resx
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="groupBox.Text" xml:space="preserve">
+    <value>Statistiek</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Woorden</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Woorden</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Woorden</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Woorden</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Woorden</value>
+  </data>
+</root>

--- a/src/Vocup/Controls/StatisticsPanel.resx
+++ b/src/Vocup/Controls/StatisticsPanel.resx
@@ -130,10 +130,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 113</value>
+    <value>64, 113</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>62, 13</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -163,10 +163,10 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 43</value>
+    <value>64, 43</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>62, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -196,10 +196,10 @@
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 87</value>
+    <value>64, 87</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>62, 13</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -229,10 +229,10 @@
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 65</value>
+    <value>64, 65</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>62, 13</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -262,10 +262,10 @@
     <value>NoControl</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 21</value>
+    <value>64, 21</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>62, 13</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -577,7 +577,7 @@
     <value>0, 0</value>
   </data>
   <data name="groupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 134</value>
+    <value>120, 134</value>
   </data>
   <data name="groupBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -625,7 +625,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 134</value>
+    <value>120, 134</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>StatisticsPanel</value>

--- a/src/Vocup/Controls/VocabularyListView.nl.resx
+++ b/src/Vocup/Controls/VocabularyListView.nl.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="foreignLangColumn.Text" xml:space="preserve">
+    <value>Vreemde taal</value>
+  </data>
+  <data name="lastPracticedColumn.Text" xml:space="preserve">
+    <value>Laatst geoefend</value>
+  </data>
+  <data name="motherTongueColumn.Text" xml:space="preserve">
+    <value>Moedertaal</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/AboutBox.nl.resx
+++ b/src/Vocup/Forms/AboutBox.nl.resx
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Over Vocup</value>
+  </data>
+  <data name="BtnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="ColHeaderLicense.Text" xml:space="preserve">
+    <value>Licentie</value>
+  </data>
+  <data name="ColHeaderName.Text" xml:space="preserve">
+    <value>Naam</value>
+  </data>
+  <data name="ColHeaderUrl.Text" xml:space="preserve">
+    <value>URL</value>
+  </data>
+  <data name="ColHeaderVersion.Text" xml:space="preserve">
+    <value>Versie</value>
+  </data>
+  <data name="LbCopyright.Text" xml:space="preserve">
+    <value>%Copyright%</value>
+  </data>
+  <data name="LbDownload.Text" xml:space="preserve">
+    <value>Download:</value>
+  </data>
+  <data name="LbLicense.Text" xml:space="preserve">
+    <value>Licentie:</value>
+  </data>
+  <data name="LbMail.Text" xml:space="preserve">
+    <value>E-mail:</value>
+  </data>
+  <data name="LbVersion.Text" xml:space="preserve">
+    <value>Versie {0} ({1}; {2})</value>
+  </data>
+  <data name="LbWebsite.Text" xml:space="preserve">
+    <value>Website:</value>
+  </data>
+  <data name="LlbDownload.Text" xml:space="preserve">
+    <value>Microsoft Store</value>
+  </data>
+  <data name="LlbProjectLicense.Text" xml:space="preserve">
+    <value>AGPL-3.0</value>
+  </data>
+  <data name="LlbProjectMail.Text" xml:space="preserve">
+    <value>daniel.dev@lerchen.net</value>
+  </data>
+  <data name="LlbProjectWebsite.Text" xml:space="preserve">
+    <value>Vocup op GitHub</value>
+  </data>
+  <data name="TpComponents.Text" xml:space="preserve">
+    <value>Componenten</value>
+  </data>
+  <data name="TpInfo.Text" xml:space="preserve">
+    <value>Info</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/EvaluationInfoDialog.nl.resx
+++ b/src/Vocup/Forms/EvaluationInfoDialog.nl.resx
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Info over de evaluatie</value>
+  </data>
+  <data name="BtnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="LbCorrectlyPracticed.Text" xml:space="preserve">
+    <value>Dit woord is minstens eenmaal goed vertaald.</value>
+  </data>
+  <data name="LbFullyPracticed.Text" xml:space="preserve">
+    <value>Dit woord is als geleerd gemarkeerd.
+
+Tip: onder Extra's/Instellingen kun je de aantallen
+voor goed vertaalde woorden aanpassen.</value>
+  </data>
+  <data name="LbUnpracticed.Text" xml:space="preserve">
+    <value>Dit woord is nog niet geoefend.</value>
+  </data>
+  <data name="LbWronglyPracticed.Text" xml:space="preserve">
+    <value>Dit woord is fout vertaald. Let op: ook woorden die eerder
+goed vertaald zijn worden na een foutieve vertaling rood
+gemarkeerd.</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/MergeFiles.nl.resx
+++ b/src/Vocup/Forms/MergeFiles.nl.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>Taalbestanden samenvoegen</value>
+    <value>Woordenboeken samenvoegen</value>
   </data>
   <data name="BtnAdd.Text" xml:space="preserve">
     <value>Toevoegen</value>

--- a/src/Vocup/Forms/MergeFiles.nl.resx
+++ b/src/Vocup/Forms/MergeFiles.nl.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Taalbestanden samenvoegen</value>
+  </data>
+  <data name="BtnAdd.Text" xml:space="preserve">
+    <value>Toevoegen</value>
+  </data>
+  <data name="BtnCancel.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="BtnRemove.Text" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="BtnSave.Text" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="BtnSpecialChar.Text" xml:space="preserve">
+    <value>Spec. tekens</value>
+  </data>
+  <data name="CbKeepResults.Text" xml:space="preserve">
+    <value>Resultaten bewaren (indien mogelijk)</value>
+  </data>
+  <data name="GroupForeignTongue.Text" xml:space="preserve">
+    <value>Vreemde taal</value>
+  </data>
+  <data name="GroupMotherTongue.Text" xml:space="preserve">
+    <value>Moedertaal</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/PracticeCountDialog.nl.resx
+++ b/src/Vocup/Forms/PracticeCountDialog.nl.resx
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BtnCount20.Text" xml:space="preserve">
+    <value>20 woorden</value>
+  </data>
+  <data name="BtnCount30.Text" xml:space="preserve">
+    <value>30 woorden</value>
+  </data>
+  <data name="BtnCount40.Text" xml:space="preserve">
+    <value>40 woorden</value>
+  </data>
+  <data name="BtnCountAll.Text" xml:space="preserve">
+    <value>Alle woorden ({0})</value>
+  </data>
+  <data name="BtnCountCustom.Text" xml:space="preserve">
+    <value>Woorden</value>
+  </data>
+  <data name="GroupCount.Text" xml:space="preserve">
+    <value>Hoeveel woorden wil je oefenen?</value>
+  </data>
+  <data name="GroupPriority.Text" xml:space="preserve">
+    <value>Welke woorden hebben prioriteit?</value>
+  </data>
+  <data name="GroupState.Text" xml:space="preserve">
+    <value>Welke woorden wil je oefenen?</value>
+  </data>
+  <data name="RbAllDates.Text" xml:space="preserve">
+    <value>Alle (gemixt)</value>
+  </data>
+  <data name="RbAllStates.Text" xml:space="preserve">
+    <value>Alle (gemixt)</value>
+  </data>
+  <data name="RbCorrectlyPracticed.Text" xml:space="preserve">
+    <value>Woorden die goed beantwoord zijn</value>
+  </data>
+  <data name="RbEarlierPracticed.Text" xml:space="preserve">
+    <value>Woorden die eerder geoefend zijn</value>
+  </data>
+  <data name="RbLaterPracticed.Text" xml:space="preserve">
+    <value>Woorden die recentelijk geoefend zijn</value>
+  </data>
+  <data name="RbUnpracticed.Text" xml:space="preserve">
+    <value>Woorden die nog niet geoefend zijn</value>
+  </data>
+  <data name="RbWronglyPracticed.Text" xml:space="preserve">
+    <value>Woorden die fout beantwoord zijn</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/PracticeCountDialog.resx
+++ b/src/Vocup/Forms/PracticeCountDialog.resx
@@ -394,7 +394,7 @@
     <value>1</value>
   </data>
   <data name="RbEarlierPracticed.Text" xml:space="preserve">
-    <value>Earlier practciced words</value>
+    <value>Earlier practiced words</value>
   </data>
   <data name="&gt;&gt;RbEarlierPracticed.Name" xml:space="preserve">
     <value>RbEarlierPracticed</value>

--- a/src/Vocup/Forms/PracticeDialog.nl.resx
+++ b/src/Vocup/Forms/PracticeDialog.nl.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Woorden oefenen</value>
+  </data>
+  <data name="BtnCancel.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="BtnContinue.Text" xml:space="preserve">
+    <value>Doorgaan</value>
+  </data>
+  <data name="BtnSpecialChar.Text" xml:space="preserve">
+    <value>Spec. tekens</value>
+  </data>
+  <data name="GroupPractice.Text" xml:space="preserve">
+    <value>Vertalen van %MotherTongue% naar %ForeignLang%</value>
+  </data>
+  <data name="GroupStatistics.Text" xml:space="preserve">
+    <value>Statistieken</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Woorden om te oefenen:</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Reeds geoefend:</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Nog niet geoefend:</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Goed beantwoord:</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Deels goed beantwoord:</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>Fout beantwoord:</value>
+  </data>
+  <data name="LbForeignLangSynonym.Text" xml:space="preserve">
+    <value>Synoniem</value>
+  </data>
+  <data name="RbCorrect.Text" xml:space="preserve">
+    <value>Goed</value>
+  </data>
+  <data name="RbPartlyCorrect.Text" xml:space="preserve">
+    <value>Deels goed</value>
+  </data>
+  <data name="RbWrong.Text" xml:space="preserve">
+    <value>Fout</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/PracticeDialog.nl.resx
+++ b/src/Vocup/Forms/PracticeDialog.nl.resx
@@ -136,7 +136,7 @@
     <value>Statistieken</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Woorden om te oefenen:</value>
+    <value>Woorden te oefenen:</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Reeds geoefend:</value>

--- a/src/Vocup/Forms/PracticeResultList.nl.resx
+++ b/src/Vocup/Forms/PracticeResultList.nl.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Evaluatie</value>
+  </data>
+  <data name="BtnContinue.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="CbDoNotShowAgain.Text" xml:space="preserve">
+    <value>Dit scherm niet meer weergeven</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Fout vertaald</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Niet vertaald</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Deels goed vertaald</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Goed vertaald</value>
+  </data>
+  <data name="LbPercentage.Text" xml:space="preserve">
+    <value>Procent:</value>
+  </data>
+  <data name="wrongInputColumn.Text" xml:space="preserve">
+    <value>Foutieve invoer</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/PrintWordSelection.nl.resx
+++ b/src/Vocup/Forms/PrintWordSelection.nl.resx
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Woorden afdrukken</value>
+  </data>
+  <data name="BtnCancel.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="BtnCheckAll.Text" xml:space="preserve">
+    <value>Alles selecteren</value>
+  </data>
+  <data name="BtnContinue.Text" xml:space="preserve">
+    <value>Doorgaan</value>
+  </data>
+  <data name="BtnUncheckAll.Text" xml:space="preserve">
+    <value>Niets selecteren</value>
+  </data>
+  <data name="CbCorrectlyPracticed.Text" xml:space="preserve">
+    <value>goed vertaald zijn</value>
+  </data>
+  <data name="CbFullyPracticed.Text" xml:space="preserve">
+    <value>als geleerd gemarkeerd zijn</value>
+  </data>
+  <data name="CbUnpracticed.Text" xml:space="preserve">
+    <value>nog niet geoefend zijn</value>
+  </data>
+  <data name="CbWronglyPracticed.Text" xml:space="preserve">
+    <value>fout vertaald zijn</value>
+  </data>
+  <data name="GroupFilter.Text" xml:space="preserve">
+    <value>Alleen woorden afdrukken die</value>
+  </data>
+  <data name="GroupPracticeMode.Text" xml:space="preserve">
+    <value>Vertaalrichting</value>
+  </data>
+  <data name="LbSelectWords.Text" xml:space="preserve">
+    <value>Selecteer de woorden die je wilt afdrukken:</value>
+  </data>
+  <data name="RbAskForForeignLang.Text" xml:space="preserve">
+    <value>Moedertaal → Vreemde taal</value>
+  </data>
+  <data name="RbAskForMotherTongue.Text" xml:space="preserve">
+    <value>Vreemde taal → Moedertaal</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/SettingsDialog.Designer.cs
+++ b/src/Vocup/Forms/SettingsDialog.Designer.cs
@@ -223,7 +223,8 @@
             this.CbLanguage.Items.AddRange(new object[] {
             resources.GetString("CbLanguage.Items"),
             resources.GetString("CbLanguage.Items1"),
-            resources.GetString("CbLanguage.Items2")});
+            resources.GetString("CbLanguage.Items2"),
+            resources.GetString("CbLanguage.Items3")});
             resources.ApplyResources(this.CbLanguage, "CbLanguage");
             this.CbLanguage.Name = "CbLanguage";
             // 

--- a/src/Vocup/Forms/SettingsDialog.cs
+++ b/src/Vocup/Forms/SettingsDialog.cs
@@ -37,6 +37,7 @@ public partial class SettingsDialog : Form
         {
             case "en-US": CbLanguage.SelectedIndex = 1; break;
             case "de-DE": CbLanguage.SelectedIndex = 2; break;
+            case "nl-NL": CbLanguage.SelectedIndex = 3; break;
             default: CbLanguage.SelectedIndex = 0; break; // System language
         }
 
@@ -88,6 +89,7 @@ public partial class SettingsDialog : Form
         {
             1 => "en-US",
             2 => "de-DE",
+            3 => "nl-NL",
             _ => null, // System language
         };
         if (settings.OverrideCulture != oldCulture)

--- a/src/Vocup/Forms/SettingsDialog.de.resx
+++ b/src/Vocup/Forms/SettingsDialog.de.resx
@@ -159,6 +159,9 @@
   <data name="CbLanguage.Items2" xml:space="preserve">
     <value>Deutsch</value>
   </data>
+  <data name="CbLanguage.Items3" xml:space="preserve">
+    <value>Niederländisch</value>
+  </data>
   <data name="CbManualCheck.Text" xml:space="preserve">
     <value>Übersetzungen beim Üben selbst bewerten</value>
   </data>

--- a/src/Vocup/Forms/SettingsDialog.nl.resx
+++ b/src/Vocup/Forms/SettingsDialog.nl.resx
@@ -142,7 +142,7 @@
     <value>Akoestische feedback inschakelen</value>
   </data>
   <data name="CbAutoSave.Text" xml:space="preserve">
-    <value>Wijzigingen automatisch opslaan in taalbestand</value>
+    <value>Wijzigingen automatisch opslaan in woordenboek</value>
   </data>
   <data name="CbColumnResize.Text" xml:space="preserve">
     <value>Kolombreedtes automatisch aanpassen</value>
@@ -211,7 +211,7 @@
     <value>User interface</value>
   </data>
   <data name="GroupVhfPath.Text" xml:space="preserve">
-    <value>Map voor taalbestanden</value>
+    <value>Map voor woordenboeken</value>
   </data>
   <data name="GroupVhrPath.Text" xml:space="preserve">
     <value>Map voor resultaatbestanden</value>
@@ -238,7 +238,7 @@ voordat het als geleerd wordt gezien?</value>
     <value>Leeg scherm</value>
   </data>
   <data name="RbRecentFile.Text" xml:space="preserve">
-    <value>Laatst geopende taalbestand</value>
+    <value>Laatst geopende woordenboek</value>
   </data>
   <data name="TabGeneral.Text" xml:space="preserve">
     <value>Algemeen</value>

--- a/src/Vocup/Forms/SettingsDialog.nl.resx
+++ b/src/Vocup/Forms/SettingsDialog.nl.resx
@@ -1,0 +1,252 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="BtnCancel.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="BtnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="BtnResetPracticeSelect.Text" xml:space="preserve">
+    <value>Instellingen terugzetten</value>
+  </data>
+  <data name="BtnResetStartScreen.Text" xml:space="preserve">
+    <value>Startscherm terugzetten</value>
+  </data>
+  <data name="BtnVhfPath.Text" xml:space="preserve">
+    <value>Bladeren</value>
+  </data>
+  <data name="BtnVhrPath.Text" xml:space="preserve">
+    <value>Bladeren</value>
+  </data>
+  <data name="CbAcousticFeedback.Text" xml:space="preserve">
+    <value>Akoestische feedback inschakelen</value>
+  </data>
+  <data name="CbAutoSave.Text" xml:space="preserve">
+    <value>Wijzigingen automatisch opslaan in taalbestand</value>
+  </data>
+  <data name="CbColumnResize.Text" xml:space="preserve">
+    <value>Kolombreedtes automatisch aanpassen</value>
+  </data>
+  <data name="CbDisableInternetServices.Text" xml:space="preserve">
+    <value>Internetdiensten deactiveren (niet aanbevolen)</value>
+  </data>
+  <data name="CbLanguage.Items" xml:space="preserve">
+    <value>Systeemtaal</value>
+  </data>
+  <data name="CbLanguage.Items1" xml:space="preserve">
+    <value>Engels</value>
+  </data>
+  <data name="CbLanguage.Items2" xml:space="preserve">
+    <value>Duits</value>
+  </data>
+  <data name="CbLanguage.Items3" xml:space="preserve">
+    <value>Nederlands</value>
+  </data>
+  <data name="CbManualCheck.Text" xml:space="preserve">
+    <value>Evalueer vertalingen zelf tijdens het oefenen</value>
+  </data>
+  <data name="CbOptionalExpressions.Text" xml:space="preserve">
+    <value>Tekst tussen haakjes als optioneel beschouwen</value>
+  </data>
+  <data name="CbShowPracticeResult.Text" xml:space="preserve">
+    <value>Resultaten tonen na oefenen</value>
+  </data>
+  <data name="CbSingleContinueButton.Text" xml:space="preserve">
+    <value>Knop slechts eenmaal indrukken na vertalen</value>
+  </data>
+  <data name="CbTolerateArticle.Text" xml:space="preserve">
+    <value>foute lidwoorden gebruikt zijn</value>
+  </data>
+  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
+    <value>slechts een van de twee synoniemen goed is</value>
+  </data>
+  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
+    <value>fouten met leestekens gemaakt zijn</value>
+  </data>
+  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
+    <value>fouten met speciale tekens gemaakt zijn</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
+    <value>fouten in witruimte gemaakt zijn</value>
+  </data>
+  <data name="GroupEvaluation.Text" xml:space="preserve">
+    <value>Evaluatie</value>
+  </data>
+  <data name="GroupLanguage.Text" xml:space="preserve">
+    <value>Taal</value>
+  </data>
+  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
+    <value>Als "Gedeeltelijk goed" markeren als</value>
+  </data>
+  <data name="GroupSave.Text" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="GroupStartScreen.Text" xml:space="preserve">
+    <value>Startscherm</value>
+  </data>
+  <data name="GroupUpdate.Text" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="GroupUserInterface.Text" xml:space="preserve">
+    <value>User interface</value>
+  </data>
+  <data name="GroupVhfPath.Text" xml:space="preserve">
+    <value>Map voor taalbestanden</value>
+  </data>
+  <data name="GroupVhrPath.Text" xml:space="preserve">
+    <value>Map voor resultaatbestanden</value>
+  </data>
+  <data name="GroupVocabularyList.Text" xml:space="preserve">
+    <value>Woordenlijst</value>
+  </data>
+  <data name="LbLanguage.Text" xml:space="preserve">
+    <value>Taal instellen</value>
+  </data>
+  <data name="LbPercentageUnpracticed.Text" xml:space="preserve">
+    <value>Welk percentage van ongeoefende woorden
+wil je hebben?</value>
+  </data>
+  <data name="LbPercentageWrongCorrect.Text" xml:space="preserve">
+    <value>Welk percentage van fout en goed beantwoorde
+woorden wil je hebben?</value>
+  </data>
+  <data name="LbPracticeCount.Text" xml:space="preserve">
+    <value>Hoe vaak moet een woord goed vertaald worden
+voordat het als geleerd wordt gezien?</value>
+  </data>
+  <data name="RbEmptyStart.Text" xml:space="preserve">
+    <value>Leeg scherm</value>
+  </data>
+  <data name="RbRecentFile.Text" xml:space="preserve">
+    <value>Laatst geopende taalbestand</value>
+  </data>
+  <data name="TabGeneral.Text" xml:space="preserve">
+    <value>Algemeen</value>
+  </data>
+  <data name="TabPractice.Text" xml:space="preserve">
+    <value>Oefen instellingen</value>
+  </data>
+  <data name="TabPracticeSelect.Text" xml:space="preserve">
+    <value>Oefen samenstelling</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/SettingsDialog.resx
+++ b/src/Vocup/Forms/SettingsDialog.resx
@@ -987,6 +987,9 @@
   <data name="CbLanguage.Items2" xml:space="preserve">
     <value>German</value>
   </data>
+  <data name="CbLanguage.Items3" xml:space="preserve">
+    <value>Dutch</value>
+  </data>
   <data name="CbLanguage.Location" type="System.Drawing.Point, System.Drawing">
     <value>150, 19</value>
   </data>

--- a/src/Vocup/Forms/SpecialCharManage.nl.resx
+++ b/src/Vocup/Forms/SpecialCharManage.nl.resx
@@ -136,7 +136,7 @@
     <value>Speciale tekens tabellen</value>
   </data>
   <data name="LbInformation.Text" xml:space="preserve">
-    <value>Als Vocup geen speciale tekens voor je gewenste taal
+    <value>Als Vocup geen speciale tekens voor de gewenste taal
 heeft kun je alle benodigde speciale tekens op internet
 opzoeken en ze in het invoerveld plakken zonder spaties.</value>
   </data>

--- a/src/Vocup/Forms/SpecialCharManage.nl.resx
+++ b/src/Vocup/Forms/SpecialCharManage.nl.resx
@@ -1,0 +1,149 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Speciale tekens beheren</value>
+  </data>
+  <data name="BtnClose.Text" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
+  <data name="BtnDelete.Text" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="BtnNew.Text" xml:space="preserve">
+    <value>Nieuw</value>
+  </data>
+  <data name="BtnSave.Text" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="GroupSpecialCharTables.Text" xml:space="preserve">
+    <value>Speciale tekens tabellen</value>
+  </data>
+  <data name="LbInformation.Text" xml:space="preserve">
+    <value>Als Vocup geen speciale tekens voor je gewenste taal
+heeft kun je alle benodigde speciale tekens op internet
+opzoeken en ze in het invoerveld plakken zonder spaties.</value>
+  </data>
+  <data name="LbLanguage.Text" xml:space="preserve">
+    <value>Taal:</value>
+  </data>
+  <data name="LbSpecialChars.Text" xml:space="preserve">
+    <value>Speciale tekens:</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/VocabularyBookSettings.nl.resx
+++ b/src/Vocup/Forms/VocabularyBookSettings.nl.resx
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BtnCancel.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="BtnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="BtnSpecialChar.Text" xml:space="preserve">
+    <value>Spec. tekens</value>
+  </data>
+  <data name="CbResetResults.Text" xml:space="preserve">
+    <value>Oefenresultaten voor alle woorden resetten</value>
+  </data>
+  <data name="GroupOptions.Text" xml:space="preserve">
+    <value>Opties</value>
+  </data>
+  <data name="GroupPracticeMode.Text" xml:space="preserve">
+    <value>Vertaalrichting</value>
+  </data>
+  <data name="LbForeignLang.Text" xml:space="preserve">
+    <value>Vreemde taal:</value>
+  </data>
+  <data name="LbMotherTongue.Text" xml:space="preserve">
+    <value>Moedertaal:</value>
+  </data>
+  <data name="RbModeAskForeignLang.Text" xml:space="preserve">
+    <value>Moedertaal → Vreemde taal</value>
+  </data>
+  <data name="RbModeAskMotherTongue.Text" xml:space="preserve">
+    <value>Vreemde taal → Moedertaal</value>
+  </data>
+</root>

--- a/src/Vocup/Forms/VocabularyBookSettings.resx
+++ b/src/Vocup/Forms/VocabularyBookSettings.resx
@@ -360,7 +360,7 @@
     <value>1</value>
   </data>
   <data name="RbModeAskMotherTongue.Text" xml:space="preserve">
-    <value>Foreign language → Mother tonuge</value>
+    <value>Foreign language → Mother tongue</value>
   </data>
   <data name="&gt;&gt;RbModeAskMotherTongue.Name" xml:space="preserve">
     <value>RbModeAskMotherTongue</value>

--- a/src/Vocup/Forms/VocabularyWordDialog.nl.resx
+++ b/src/Vocup/Forms/VocabularyWordDialog.nl.resx
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BtnCancel.Text" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="BtnContinue.Text" xml:space="preserve">
+    <value>Verder</value>
+  </data>
+  <data name="BtnSpecialChar.Text" xml:space="preserve">
+    <value>Spec. tekens</value>
+  </data>
+  <data name="CbResetResults.Text" xml:space="preserve">
+    <value>Resultaten voor dit woord resetten</value>
+  </data>
+  <data name="GroupForeignLang.Text" xml:space="preserve">
+    <value>Vreemde taal:</value>
+  </data>
+  <data name="GroupMotherTongue.Text" xml:space="preserve">
+    <value>Moedertaal:</value>
+  </data>
+  <data name="GroupOptions.Text" xml:space="preserve">
+    <value>Opties</value>
+  </data>
+</root>

--- a/src/Vocup/MainForm.nl.resx
+++ b/src/Vocup/MainForm.nl.resx
@@ -1,0 +1,253 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TsmiCreateBook.Text" xml:space="preserve">
+    <value>Nieuw taalbestand maken</value>
+  </data>
+  <data name="TsmiOpenBook.Text" xml:space="preserve">
+    <value>Taalbestand openen...</value>
+  </data>
+  <data name="TsmiCloseBook.Text" xml:space="preserve">
+    <value>Taalbestand sluiten</value>
+  </data>
+  <data name="TsmiSave.Text" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="TsmiSaveAs.Text" xml:space="preserve">
+    <value>Opslaan als...</value>
+  </data>
+  <data name="TsmiImport.Text" xml:space="preserve">
+    <value>Importeren</value>
+  </data>
+  <data name="TsmiExport.Text" xml:space="preserve">
+    <value>Exporteren</value>
+  </data>
+  <data name="TsmiOpenInExplorer.Text" xml:space="preserve">
+    <value>In Verkenner openen</value>
+  </data>
+  <data name="TsmiPrint.Text" xml:space="preserve">
+    <value>Afdrukken</value>
+  </data>
+  <data name="TsmiExitApplication.Text" xml:space="preserve">
+    <value>Afsluiten</value>
+  </data>
+  <data name="TsmiRootFile.Text" xml:space="preserve">
+    <value>Bestand</value>
+  </data>
+  <data name="TsmiAddWord.Text" xml:space="preserve">
+    <value>Nieuw woord toevoegen</value>
+  </data>
+  <data name="TsmiEditWord.Text" xml:space="preserve">
+    <value>Woord bewerken</value>
+  </data>
+  <data name="TsmiDeleteWord.Text" xml:space="preserve">
+    <value>Woord verwijderen</value>
+  </data>
+  <data name="TsmiRootEdit.Text" xml:space="preserve">
+    <value>Bewerken</value>
+  </data>
+  <data name="TsmiPractice.Text" xml:space="preserve">
+    <value>Woorden oefenen</value>
+  </data>
+  <data name="TsmiBookOptions.Text" xml:space="preserve">
+    <value>Taalbestand opties</value>
+  </data>
+  <data name="TsmiMerge.Text" xml:space="preserve">
+    <value>Taalbestanden samenvoegen</value>
+  </data>
+  <data name="TsmiSpecialChar.Text" xml:space="preserve">
+    <value>Speciale tekens beheren</value>
+  </data>
+  <data name="TsmiSettings.Text" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="TsmiRootTools.Text" xml:space="preserve">
+    <value>Extra's</value>
+  </data>
+  <data name="TsmiHelp.Text" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="TsmiEvaluationInfo.Text" xml:space="preserve">
+    <value>Info over de evaluatie</value>
+  </data>
+  <data name="TsmiUpdate.Text" xml:space="preserve">
+    <value>Naar updates zoeken...</value>
+  </data>
+  <data name="TsmiAbout.Text" xml:space="preserve">
+    <value>Over Vocup</value>
+  </data>
+  <data name="TsmiRootHelp.Text" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="BtnBookSettings.Text" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="BtnPractice.Text" xml:space="preserve">
+    <value>Oefenen</value>
+  </data>
+  <data name="GroupBook.Text" xml:space="preserve">
+    <value>Taalbestand:</value>
+  </data>
+  <data name="BtnSearchWord.Text" xml:space="preserve">
+    <value>Zoeken</value>
+  </data>
+  <data name="GroupSearch.Text" xml:space="preserve">
+    <value>Naar woorden zoeken:</value>
+  </data>
+  <data name="BtnAddWord.Text" xml:space="preserve">
+    <value>Toevoegen</value>
+  </data>
+  <data name="BtnDeleteWord.Text" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="BtnEditWord.Text" xml:space="preserve">
+    <value>Bewerken</value>
+  </data>
+  <data name="GroupWord.Text" xml:space="preserve">
+    <value>Woord:</value>
+  </data>
+  <data name="StatusLbOldVersion.Text" xml:space="preserve">
+    <value>Incompatibele versie gevonden</value>
+  </data>
+  <data name="LbEmptyForm.Text" xml:space="preserve">
+    <value>Het is aardig leeg hier!
+Open een taalbestand of maak een nieuw bestand aan.</value>
+  </data>
+  <data name="TsbCreateBook.Text" xml:space="preserve">
+    <value>Nieuw taalbestand aanmaken</value>
+  </data>
+  <data name="TsbOpenBook.Text" xml:space="preserve">
+    <value>Taalbestand openen</value>
+  </data>
+  <data name="TsbSave.Text" xml:space="preserve">
+    <value>Taalbestand opslaan</value>
+  </data>
+  <data name="TsbPrint.Text" xml:space="preserve">
+    <value>Taalbestand afdrukken</value>
+  </data>
+  <data name="TsbEvaluationInfo.Text" xml:space="preserve">
+    <value>Info over de evaluatie</value>
+  </data>
+  <data name="toolStripLabel.Text" xml:space="preserve">
+    <value>Info over de evaluatie:</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Vocup</value>
+  </data>
+</root>

--- a/src/Vocup/MainForm.nl.resx
+++ b/src/Vocup/MainForm.nl.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TsmiCreateBook.Text" xml:space="preserve">
-    <value>Nieuw taalbestand maken</value>
+    <value>Nieuw woordenboek maken</value>
   </data>
   <data name="TsmiOpenBook.Text" xml:space="preserve">
-    <value>Taalbestand openen...</value>
+    <value>Woordenboek openen...</value>
   </data>
   <data name="TsmiCloseBook.Text" xml:space="preserve">
-    <value>Taalbestand sluiten</value>
+    <value>Woordenboek sluiten</value>
   </data>
   <data name="TsmiSave.Text" xml:space="preserve">
     <value>Opslaan</value>
@@ -166,10 +166,10 @@
     <value>Woorden oefenen</value>
   </data>
   <data name="TsmiBookOptions.Text" xml:space="preserve">
-    <value>Taalbestand opties</value>
+    <value>Woordenboek opties</value>
   </data>
   <data name="TsmiMerge.Text" xml:space="preserve">
-    <value>Taalbestanden samenvoegen</value>
+    <value>Woordenboeken samenvoegen</value>
   </data>
   <data name="TsmiSpecialChar.Text" xml:space="preserve">
     <value>Speciale tekens beheren</value>
@@ -202,7 +202,7 @@
     <value>Oefenen</value>
   </data>
   <data name="GroupBook.Text" xml:space="preserve">
-    <value>Taalbestand:</value>
+    <value>Woordenboek:</value>
   </data>
   <data name="BtnSearchWord.Text" xml:space="preserve">
     <value>Zoeken</value>
@@ -227,19 +227,19 @@
   </data>
   <data name="LbEmptyForm.Text" xml:space="preserve">
     <value>Het is aardig leeg hier!
-Open een taalbestand of maak een nieuw bestand aan.</value>
+Open een woordenboek of maak een nieuwe aan.</value>
   </data>
   <data name="TsbCreateBook.Text" xml:space="preserve">
-    <value>Nieuw taalbestand aanmaken</value>
+    <value>Nieuw woordenboek aanmaken</value>
   </data>
   <data name="TsbOpenBook.Text" xml:space="preserve">
-    <value>Taalbestand openen</value>
+    <value>Woordenboek openen</value>
   </data>
   <data name="TsbSave.Text" xml:space="preserve">
-    <value>Taalbestand opslaan</value>
+    <value>Woordenboek opslaan</value>
   </data>
   <data name="TsbPrint.Text" xml:space="preserve">
-    <value>Taalbestand afdrukken</value>
+    <value>Woordenboek afdrukken</value>
   </data>
   <data name="TsbEvaluationInfo.Text" xml:space="preserve">
     <value>Info over de evaluatie</value>

--- a/src/Vocup/MainForm.resx
+++ b/src/Vocup/MainForm.resx
@@ -400,7 +400,7 @@
     <value>10, 43</value>
   </data>
   <data name="TbSearchWord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 20</value>
+    <value>100, 20</value>
   </data>
   <data name="TbSearchWord.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -442,7 +442,7 @@
     <value>10, 50</value>
   </data>
   <data name="BtnBookSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
+    <value>100, 23</value>
   </data>
   <data name="BtnBookSettings.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -486,7 +486,7 @@
     <value>10, 21</value>
   </data>
   <data name="BtnPractice.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
+    <value>100, 23</value>
   </data>
   <data name="BtnPractice.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -513,7 +513,7 @@
     <value>2, 0</value>
   </data>
   <data name="GroupBook.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 88</value>
+    <value>120, 88</value>
   </data>
   <data name="GroupBook.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -561,7 +561,7 @@
     <value>10, 69</value>
   </data>
   <data name="BtnSearchWord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
+    <value>100, 23</value>
   </data>
   <data name="BtnSearchWord.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -588,7 +588,7 @@
     <value>2, 234</value>
   </data>
   <data name="GroupSearch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 100</value>
+    <value>120, 100</value>
   </data>
   <data name="GroupSearch.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -635,7 +635,7 @@
     <value>10, 19</value>
   </data>
   <data name="BtnAddWord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
+    <value>100, 23</value>
   </data>
   <data name="BtnAddWord.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -681,7 +681,7 @@
     <value>10, 77</value>
   </data>
   <data name="BtnDeleteWord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
+    <value>100, 23</value>
   </data>
   <data name="BtnDeleteWord.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -726,7 +726,7 @@
     <value>10, 48</value>
   </data>
   <data name="BtnEditWord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
+    <value>100, 23</value>
   </data>
   <data name="BtnEditWord.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -753,7 +753,7 @@
     <value>2, 103</value>
   </data>
   <data name="GroupWord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 115</value>
+    <value>120, 115</value>
   </data>
   <data name="GroupWord.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -814,7 +814,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="GroupStatistics.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 134</value>
+    <value>120, 134</value>
   </data>
   <data name="GroupStatistics.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -835,10 +835,10 @@
     <value>Fill</value>
   </data>
   <data name="SideBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>665, 3</value>
+    <value>655, 3</value>
   </data>
   <data name="SideBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 482</value>
+    <value>124, 482</value>
   </data>
   <data name="SideBar.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -907,7 +907,7 @@
     <value>0, 0</value>
   </data>
   <data name="LbEmptyForm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 482</value>
+    <value>490, 482</value>
   </data>
   <data name="LbEmptyForm.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -944,7 +944,7 @@ Just open a vocabulary book or create a new one.</value>
     <value>1</value>
   </data>
   <data name="SplitContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 482</value>
+    <value>644, 482</value>
   </data>
   <data name="SplitContainer.SplitterDistance" type="System.Int32, mscorlib">
     <value>150</value>
@@ -1082,7 +1082,7 @@ Just open a vocabulary book or create a new one.</value>
     <value>0</value>
   </data>
   <data name="TableLayout.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="SideBar" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="SplitContainer" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,120" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="SideBar" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="SplitContainer" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,130" /&gt;&lt;Rows Styles="Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/src/Vocup/Properties/Messages.nl.resx
+++ b/src/Vocup/Properties/Messages.nl.resx
@@ -126,7 +126,7 @@ Hint: in de instellingen kun je configureren hoe vaak een woord goed vertaald mo
     <value>Gefeliciteerd!</value>
   </data>
   <data name="BrowseVhfPath" xml:space="preserve">
-    <value>Selecteer de standaard map voor je taalbestanden.</value>
+    <value>Selecteer de standaard map voor je woordenboeken.</value>
   </data>
   <data name="CsvExportError" xml:space="preserve">
     <value>Er is een onverwachte fout opgetreden tijdens het exporteren naar een CSV bestand. 
@@ -159,18 +159,18 @@ Zorg ervoor dat het CSV bestand geëxporteerd wordt met Excel in UTF-8 formaat. 
     <value>Ongeldige CSV header</value>
   </data>
   <data name="CsvInvalidLanguages" xml:space="preserve">
-    <value>Wil je een {0} - {1} taalbestand importeren, ondanks dat de talen niet overeenkomen?
+    <value>Wil je een {0} - {1} woordenboek importeren, ondanks dat de talen niet overeenkomen?
 Als {0} en {1} woorden zijn en geen talen, denk er dan aan om de eerste rij van het CSV bestand te vullen met je moeder taal in de linker kolom en de vreemde taal in de rechter kolom.</value>
     <comment>{0}: Source, {1}: Target</comment>
   </data>
   <data name="EditAddDuplicate" xml:space="preserve">
-    <value>Dit woord bestaat al in je taalbestand. Wil je de invoer negeren?</value>
+    <value>Dit woord bestaat al in je woordenboek. Wil je de invoer negeren?</value>
   </data>
   <data name="EditDuplicateT" xml:space="preserve">
     <value>Woord bestaat al</value>
   </data>
   <data name="EditToDuplicate" xml:space="preserve">
-    <value>Dit gewijzigde woord bestaat al in je taalbestand. Wil je dit woord verwijderen?</value>
+    <value>Dit gewijzigde woord bestaat al in je woordenboek. Wil je dit woord verwijderen?</value>
   </data>
   <data name="GeneralSaveChanges" xml:space="preserve">
     <value>Wil je de wijzigingen en/of oefenresultaten opslaan?</value>
@@ -179,13 +179,13 @@ Als {0} en {1} woorden zijn en geen talen, denk er dan aan om de eerste rij van 
     <value>Opslaan?</value>
   </data>
   <data name="LegacyVersionUninstall" xml:space="preserve">
-    <value>Er is een verouderde versie van Vocup gevonden op je computer. Dit kan problemen geven met de automatische bestandstype associatie en kan ervoor zorgen dat taalbestanden niet geopend kunnen worden. Wil je de verouderde versie deïnstalleren?</value>
+    <value>Er is een verouderde versie van Vocup gevonden op je computer. Dit kan problemen geven met de automatische bestandstype associatie en kan ervoor zorgen dat woordenboeken niet geopend kunnen worden. Wil je de verouderde versie deïnstalleren?</value>
   </data>
   <data name="LegacyVersionUninstallT" xml:space="preserve">
     <value>Incompatibele versie deïnstalleren?</value>
   </data>
   <data name="MergeOverride" xml:space="preserve">
-    <value>Een taalbestand uit hetzelfde pad is reeds ingeladen. Wil je het huidige taalbestand laden en bestaande data overschrijven?</value>
+    <value>Een woordenboek uit hetzelfde pad is reeds ingeladen. Wil je het huidige woordenboek laden en bestaande data overschrijven?</value>
   </data>
   <data name="MergeOverrideT" xml:space="preserve">
     <value>Data overschrijven?</value>
@@ -197,7 +197,7 @@ Als {0} en {1} woorden zijn en geen talen, denk er dan aan om de eerste rij van 
     <value>Vocup kon niet worden opgestart</value>
   </data>
   <data name="OpenInExplorerError" xml:space="preserve">
-    <value>Het huidige taalbestand kon niet worden geopend in Verkenner. Let op dat deze functionaliteit niet beschikbaar is op sommige besturingssystemen zoals Linux of Windows 10 S. 
+    <value>Het huidige woordenboek kon niet worden geopend in Verkenner. Let op dat deze functionaliteit niet beschikbaar is op sommige besturingssystemen zoals Linux of Windows 10 S. 
 Details: {0}</value>
     <comment>{0}: ErrorDetails</comment>
   </data>
@@ -205,7 +205,7 @@ Details: {0}</value>
     <value>Fout bij openen in Verkenner</value>
   </data>
   <data name="OpenInExplorerNotFound" xml:space="preserve">
-    <value>Taalbestand {0} bestaat niet meer.</value>
+    <value>Woordenboek {0} bestaat niet meer.</value>
     <comment>{0}: FilePath</comment>
   </data>
   <data name="OpenInExplorerNotFoundT" xml:space="preserve">
@@ -218,7 +218,7 @@ Details: {0}</value>
     <value>Nu opslaan?</value>
   </data>
   <data name="OpenUnknownFile" xml:space="preserve">
-    <value>Vocup kan bestand {0} niet openen omdat het geen taalbestand of Vocup back-up bestand is.</value>
+    <value>Vocup kan bestand {0} niet openen omdat het geen woordenboek of Vocup back-up bestand is.</value>
     <comment>{0}: FilePath</comment>
   </data>
   <data name="OpenUnknownFileT" xml:space="preserve">
@@ -278,41 +278,41 @@ Details: {0}</value>
     <value>Herstellen gereed</value>
   </data>
   <data name="VhfCorruptFile" xml:space="preserve">
-    <value>Het taalbestand is beschadigd en kon niet worden geopend.</value>
+    <value>Het woordenboek is beschadigd en kon niet worden geopend.</value>
   </data>
   <data name="VhfCorruptFileT" xml:space="preserve">
-    <value>Beschadigd taalbestand</value>
+    <value>Beschadigd woordenboek</value>
   </data>
   <data name="VhfInvalidLanguages" xml:space="preserve">
-    <value>Moedertaal en vreemde taal konden niet uit het taalbestand worden gelezen of zijn identiek aan elkaar.
+    <value>Moedertaal en vreemde taal konden niet uit het woordenboek worden gelezen of zijn identiek aan elkaar.
 Zorg ervoor dat het bestand niet leeg is.</value>
   </data>
   <data name="VhfInvalidRow" xml:space="preserve">
-    <value>Een regel in dit taalbestand is ongeldig. Hierdoor kan het bestand niet worden geopend.</value>
+    <value>Een regel in dit woordenboek is ongeldig. Hierdoor kan het bestand niet worden geopend.</value>
   </data>
   <data name="VhfInvalidVersion" xml:space="preserve">
-    <value>Het versieveld van het taalbestand kon niet worden gelezen.
+    <value>Het versieveld van het woordenboek kon niet worden gelezen.
 Controleer of het bestand niet leeg is.</value>
   </data>
   <data name="VhfInvalidVhrCode" xml:space="preserve">
-    <value>Het resultatenbestand behorend bij het taalbestand kon niet worden gelezen.
+    <value>Het resultatenbestand behorend bij het woordenboek kon niet worden gelezen.
 Controleer of het bestand niet leeg is.</value>
   </data>
   <data name="VhfMustUpdate" xml:space="preserve">
-    <value>Het taalbestand vereist een nieuwere versie van Vocup. Controleer op updates vanuit de applicatie of kijk op internet.</value>
+    <value>Het woordenboek vereist een nieuwere versie van Vocup. Controleer op updates vanuit de applicatie of kijk op internet.</value>
   </data>
   <data name="VhfMustUpdateT" xml:space="preserve">
     <value>Update vereist</value>
   </data>
   <data name="VhfPathInvalid" xml:space="preserve">
-    <value>Het geselecteerde pad is niet geschikt om taalbestanden op te slaan. Gebruik hier geen optische schijven of systeemmappen.</value>
+    <value>Het geselecteerde pad is niet geschikt om woordenboeken op te slaan. Gebruik hier geen optische schijven of systeemmappen.</value>
   </data>
   <data name="VhfPathNotFound" xml:space="preserve">
-    <value>De map voor taalbestanden was niet gevonden op {0}. Vocup zal je configuratie aanpassen naar de standaard documenten map. Je kunt deze instelling op elk moment aanpassen.</value>
+    <value>De map voor woordenboeken was niet gevonden op {0}. Vocup zal je configuratie aanpassen naar de standaard documenten map. Je kunt deze instelling op elk moment aanpassen.</value>
     <comment>{0}: Path</comment>
   </data>
   <data name="VhfPathNotFoundT" xml:space="preserve">
-    <value>Map voor taalbestanden niet gevonden</value>
+    <value>Map voor woordenboeken niet gevonden</value>
   </data>
   <data name="VhrCorruptFile" xml:space="preserve">
     <value>Het resultatenbestand is beschadigd en zal worden verwijderd. Hierdoor zal je je oefenresultaten kwijt raken.</value>
@@ -321,10 +321,10 @@ Controleer of het bestand niet leeg is.</value>
     <value>Beschadigd resultatenbestand</value>
   </data>
   <data name="VhrInvalidRowCount" xml:space="preserve">
-    <value>Het resultatenbestand match niet met het taalbestand. Alle resultaten zullen worden verwijderd.</value>
+    <value>Het resultatenbestand match niet met het woordenboek. Alle resultaten zullen worden verwijderd.</value>
   </data>
   <data name="VhrInvalidRowCountAndOtherFile" xml:space="preserve">
-    <value>Het resultatenbestand is in gebruik door een ander taalbestand. Resultaten kunnen niet worden ingeladen.</value>
+    <value>Het resultatenbestand is in gebruik door een ander woordenboek. Resultaten kunnen niet worden ingeladen.</value>
   </data>
   <data name="VhrPathInvalid" xml:space="preserve">
     <value>Het gekozen pad is niet geschikt om oefenresultaten op te slaan. Gebruik hier geen optische schijven of systeemmappen.</value>
@@ -336,10 +336,10 @@ Controleer of het bestand niet leeg is.</value>
     <value>Map voor oefenresultaten niet gevonden</value>
   </data>
   <data name="VocupFileWriteError" xml:space="preserve">
-    <value>Een taal- of resultatenbestand kon niet worden opgeslagen.</value>
+    <value>Een woordenboek of resultatenbestand kon niet worden opgeslagen.</value>
   </data>
   <data name="VocupFileWriteErrorEx" xml:space="preserve">
-    <value>Een taal- of resultatenbestand kon niet worden opgeslagen: 
+    <value>Een woordenboek of resultatenbestand kon niet worden opgeslagen: 
 {0}</value>
     <comment>{0}: ErrorDetails</comment>
   </data>

--- a/src/Vocup/Properties/Messages.nl.resx
+++ b/src/Vocup/Properties/Messages.nl.resx
@@ -1,0 +1,349 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BookPracticeFinished" xml:space="preserve">
+    <value>Je hebt alle woorden meerdere keren goed vertaald. 
+
+Hint: in de instellingen kun je configureren hoe vaak een woord goed vertaald moet worden voordat het gemarkeerd wordt als geleerd.</value>
+  </data>
+  <data name="BookPracticeFinishedT" xml:space="preserve">
+    <value>Gefeliciteerd!</value>
+  </data>
+  <data name="BrowseVhfPath" xml:space="preserve">
+    <value>Selecteer de standaard map voor je taalbestanden.</value>
+  </data>
+  <data name="CsvExportError" xml:space="preserve">
+    <value>Er is een onverwachte fout opgetreden tijdens het exporteren naar een CSV bestand. 
+Details:
+{0}</value>
+    <comment>{0}: ErrorDetails</comment>
+  </data>
+  <data name="CsvExportSave" xml:space="preserve">
+    <value>Wil je de aanpassingen opslaan alvorens te exporteren naar een CSV bestand? Je kunt de wijzigingen later nog opslaan. Vocup exporteert altijd de huidige versie inclusief onopgeslagen wijzigingen.</value>
+  </data>
+  <data name="CsvExportSaveT" xml:space="preserve">
+    <value>Nu opslaan?</value>
+  </data>
+  <data name="CsvImportError" xml:space="preserve">
+    <value>Er is een onverwachte fout opgetreden tijdens het exporteren van een CSV bestand.
+ Details:
+{0}</value>
+    <comment>{0}: ErrorDetails</comment>
+  </data>
+  <data name="CsvInvalidHeader" xml:space="preserve">
+    <value>De CSV header kon niet worden gelezen.
+Zorg ervoor dat het bestand niet leeg is.</value>
+  </data>
+  <data name="CsvInvalidHeaderColumns" xml:space="preserve">
+    <value>De CSV header bestaat uit {0} kolommen maar hoort exact 2 kolommen te zijn.
+Zorg ervoor dat het CSV bestand geëxporteerd wordt met Excel in UTF-8 formaat. Bestanden geëxporteerd met oudere versies van Vocup zijn niet meer compatibel.</value>
+    <comment>{0}: Count of columns</comment>
+  </data>
+  <data name="CsvInvalidHeaderT" xml:space="preserve">
+    <value>Ongeldige CSV header</value>
+  </data>
+  <data name="CsvInvalidLanguages" xml:space="preserve">
+    <value>Wil je een {0} - {1} taalbestand importeren, ondanks dat de talen niet overeenkomen?
+Als {0} en {1} woorden zijn en geen talen, denk er dan aan om de eerste rij van het CSV bestand te vullen met je moeder taal in de linker kolom en de vreemde taal in de rechter kolom.</value>
+    <comment>{0}: Source, {1}: Target</comment>
+  </data>
+  <data name="EditAddDuplicate" xml:space="preserve">
+    <value>Dit woord bestaat al in je taalbestand. Wil je de invoer negeren?</value>
+  </data>
+  <data name="EditDuplicateT" xml:space="preserve">
+    <value>Woord bestaat al</value>
+  </data>
+  <data name="EditToDuplicate" xml:space="preserve">
+    <value>Dit gewijzigde woord bestaat al in je taalbestand. Wil je dit woord verwijderen?</value>
+  </data>
+  <data name="GeneralSaveChanges" xml:space="preserve">
+    <value>Wil je de wijzigingen en/of oefenresultaten opslaan?</value>
+  </data>
+  <data name="GeneralSaveChangesT" xml:space="preserve">
+    <value>Opslaan?</value>
+  </data>
+  <data name="LegacyVersionUninstall" xml:space="preserve">
+    <value>Er is een verouderde versie van Vocup gevonden op je computer. Dit kan problemen geven met de automatische bestandstype associatie en kan ervoor zorgen dat taalbestanden niet geopend kunnen worden. Wil je de verouderde versie deïnstalleren?</value>
+  </data>
+  <data name="LegacyVersionUninstallT" xml:space="preserve">
+    <value>Incompatibele versie deïnstalleren?</value>
+  </data>
+  <data name="MergeOverride" xml:space="preserve">
+    <value>Een taalbestand uit hetzelfde pad is reeds ingeladen. Wil je het huidige taalbestand laden en bestaande data overschrijven?</value>
+  </data>
+  <data name="MergeOverrideT" xml:space="preserve">
+    <value>Data overschrijven?</value>
+  </data>
+  <data name="MutexLockedButNoOtherProcess" xml:space="preserve">
+    <value>Er draait al een andere instantie van Vocup of er wordt momenteel een update van Vocup geïnstalleerd. Als dit probleem blijft bestaan, zoek dan naar actieve Vocup processen in Taakbeheer of herstart je computer.</value>
+  </data>
+  <data name="MutexLockedButNoOtherProcessT" xml:space="preserve">
+    <value>Vocup kon niet worden opgestart</value>
+  </data>
+  <data name="OpenInExplorerError" xml:space="preserve">
+    <value>Het huidige taalbestand kon niet worden geopend in Verkenner. Let op dat deze functionaliteit niet beschikbaar is op sommige besturingssystemen zoals Linux of Windows 10 S. 
+Details: {0}</value>
+    <comment>{0}: ErrorDetails</comment>
+  </data>
+  <data name="OpenInExplorerErrorT" xml:space="preserve">
+    <value>Fout bij openen in Verkenner</value>
+  </data>
+  <data name="OpenInExplorerNotFound" xml:space="preserve">
+    <value>Taalbestand {0} bestaat niet meer.</value>
+    <comment>{0}: FilePath</comment>
+  </data>
+  <data name="OpenInExplorerNotFoundT" xml:space="preserve">
+    <value>Bestand niet gevonden</value>
+  </data>
+  <data name="OpenInExplorerSave" xml:space="preserve">
+    <value>Je kunt in ieder geval de wijzigingen op een later moment nog opslaan.</value>
+  </data>
+  <data name="OpenInExplorerSaveT" xml:space="preserve">
+    <value>Nu opslaan?</value>
+  </data>
+  <data name="OpenUnknownFile" xml:space="preserve">
+    <value>Vocup kan bestand {0} niet openen omdat het geen taalbestand of Vocup back-up bestand is.</value>
+    <comment>{0}: FilePath</comment>
+  </data>
+  <data name="OpenUnknownFileT" xml:space="preserve">
+    <value>Onbekend bestandsformaat</value>
+  </data>
+  <data name="SettingsRestartRequired" xml:space="preserve">
+    <value>Je moet Vocup opnieuw opstarten om alle gewijzigde instellingen toe te passen.</value>
+  </data>
+  <data name="SettingsRestartRequiredT" xml:space="preserve">
+    <value>Opnieuw opstarten vereist</value>
+  </data>
+  <data name="SpecialCharAlreadyExists" xml:space="preserve">
+    <value>Er bestaan al speciale tekens voor deze taal</value>
+  </data>
+  <data name="SpecialCharCorruptedFile" xml:space="preserve">
+    <value>Het bestand met speciale tekens {0} kon niet worden geladen. Controleer het bestand {1} en verwijder het indien nodig.</value>
+    <comment>{0}: Language, {1}: FilePath</comment>
+  </data>
+  <data name="SpecialCharCorruptedFileT" xml:space="preserve">
+    <value>Beschadigd bestand</value>
+  </data>
+  <data name="SpecialCharDeleteError" xml:space="preserve">
+    <value>Fout bij verwijderen van bestand met speciale tekens voor taal {0}: 
+{1}</value>
+    <comment>{0}: Language, {1}: ErrorDetails</comment>
+  </data>
+  <data name="SpecialCharDeleteErrorT" xml:space="preserve">
+    <value>Fout bij verwijderen</value>
+  </data>
+  <data name="SpecialCharSaveError" xml:space="preserve">
+    <value>Fout bij opslaan van bestand met speciale tekens voor taal {0}:
+{1}</value>
+    <comment>{0}: Language, {1}: ErrorDetails</comment>
+  </data>
+  <data name="SpecialCharSaveErrorT" xml:space="preserve">
+    <value>Fout bij opslaan</value>
+  </data>
+  <data name="UnexpectedErrorT" xml:space="preserve">
+    <value>Onbekende fout</value>
+  </data>
+  <data name="VdpCorruptFile" xml:space="preserve">
+    <value>Het Vocup back-up bestand is beschadigd en kon niet worden geopend: 
+{0}</value>
+    <comment>{0}: ErrorDetails</comment>
+  </data>
+  <data name="VdpCorruptFileT" xml:space="preserve">
+    <value>Beschadigd bestand</value>
+  </data>
+  <data name="VdpRestored" xml:space="preserve">
+    <value>Samenvatting
+ -  {0} bestand(en) hersteld
+ -  {1} bestand(en) overgeslagen
+ -  {2} bestand(en) mislukt</value>
+    <comment>{0}: Restored, {1}: Skipped, {2}: Failed</comment>
+  </data>
+  <data name="VdpRestoredT" xml:space="preserve">
+    <value>Herstellen gereed</value>
+  </data>
+  <data name="VhfCorruptFile" xml:space="preserve">
+    <value>Het taalbestand is beschadigd en kon niet worden geopend.</value>
+  </data>
+  <data name="VhfCorruptFileT" xml:space="preserve">
+    <value>Beschadigd taalbestand</value>
+  </data>
+  <data name="VhfInvalidLanguages" xml:space="preserve">
+    <value>Moedertaal en vreemde taal konden niet uit het taalbestand worden gelezen of zijn identiek aan elkaar.
+Zorg ervoor dat het bestand niet leeg is.</value>
+  </data>
+  <data name="VhfInvalidRow" xml:space="preserve">
+    <value>Een regel in dit taalbestand is ongeldig. Hierdoor kan het bestand niet worden geopend.</value>
+  </data>
+  <data name="VhfInvalidVersion" xml:space="preserve">
+    <value>Het versieveld van het taalbestand kon niet worden gelezen.
+Controleer of het bestand niet leeg is.</value>
+  </data>
+  <data name="VhfInvalidVhrCode" xml:space="preserve">
+    <value>Het resultatenbestand behorend bij het taalbestand kon niet worden gelezen.
+Controleer of het bestand niet leeg is.</value>
+  </data>
+  <data name="VhfMustUpdate" xml:space="preserve">
+    <value>Het taalbestand vereist een nieuwere versie van Vocup. Controleer op updates vanuit de applicatie of kijk op internet.</value>
+  </data>
+  <data name="VhfMustUpdateT" xml:space="preserve">
+    <value>Update vereist</value>
+  </data>
+  <data name="VhfPathInvalid" xml:space="preserve">
+    <value>Het geselecteerde pad is niet geschikt om taalbestanden op te slaan. Gebruik hier geen optische schijven of systeemmappen.</value>
+  </data>
+  <data name="VhfPathNotFound" xml:space="preserve">
+    <value>De map voor taalbestanden was niet gevonden op {0}. Vocup zal je configuratie aanpassen naar de standaard documenten map. Je kunt deze instelling op elk moment aanpassen.</value>
+    <comment>{0}: Path</comment>
+  </data>
+  <data name="VhfPathNotFoundT" xml:space="preserve">
+    <value>Map voor taalbestanden niet gevonden</value>
+  </data>
+  <data name="VhrCorruptFile" xml:space="preserve">
+    <value>Het resultatenbestand is beschadigd en zal worden verwijderd. Hierdoor zal je je oefenresultaten kwijt raken.</value>
+  </data>
+  <data name="VhrCorruptFileT" xml:space="preserve">
+    <value>Beschadigd resultatenbestand</value>
+  </data>
+  <data name="VhrInvalidRowCount" xml:space="preserve">
+    <value>Het resultatenbestand match niet met het taalbestand. Alle resultaten zullen worden verwijderd.</value>
+  </data>
+  <data name="VhrInvalidRowCountAndOtherFile" xml:space="preserve">
+    <value>Het resultatenbestand is in gebruik door een ander taalbestand. Resultaten kunnen niet worden ingeladen.</value>
+  </data>
+  <data name="VhrPathInvalid" xml:space="preserve">
+    <value>Het gekozen pad is niet geschikt om oefenresultaten op te slaan. Gebruik hier geen optische schijven of systeemmappen.</value>
+  </data>
+  <data name="VhrPathNotFound" xml:space="preserve">
+    <value>Map voor oefenresultaten niet gevonden op {0}. Vocup zal je configuratie vervangen met de standaard applicatie datamap. Je kunt deze instelling op elk moment aanpassen.</value>
+  </data>
+  <data name="VhrPathNotFoundT" xml:space="preserve">
+    <value>Map voor oefenresultaten niet gevonden</value>
+  </data>
+  <data name="VocupFileWriteError" xml:space="preserve">
+    <value>Een taal- of resultatenbestand kon niet worden opgeslagen.</value>
+  </data>
+  <data name="VocupFileWriteErrorEx" xml:space="preserve">
+    <value>Een taal- of resultatenbestand kon niet worden opgeslagen: 
+{0}</value>
+    <comment>{0}: ErrorDetails</comment>
+  </data>
+  <data name="VocupFileWriteErrorT" xml:space="preserve">
+    <value>Fout bij opslaan</value>
+  </data>
+</root>

--- a/src/Vocup/Properties/Messages.resx
+++ b/src/Vocup/Properties/Messages.resx
@@ -135,7 +135,7 @@ Details:
     <comment>{0}: ErrorDetails</comment>
   </data>
   <data name="CsvExportSave" xml:space="preserve">
-    <value>Do you want to save your changes before exporting a CSV file? You can save your changes later on. Vocup always exports the current version including any unsafed changes.</value>
+    <value>Do you want to save your changes before exporting a CSV file? You can save your changes later on. Vocup always exports the current version including any unsaved changes.</value>
   </data>
   <data name="CsvExportSaveT" xml:space="preserve">
     <value>Save now?</value>
@@ -197,7 +197,7 @@ If {0} and {1} are vocabulary words and no languages, please remember to fill th
     <value>Vocup could not be started</value>
   </data>
   <data name="OpenInExplorerError" xml:space="preserve">
-    <value>The current vocabulary book could not be opened in Explorer. Please be aware that this feature is not avalaible on some operatening systems like Linux or Windows 10 S.
+    <value>The current vocabulary book could not be opened in Explorer. Please be aware that this feature is not avalaible on some operating systems like Linux or Windows 10 S.
 Details: {0}</value>
     <comment>{0}: ErrorDetails</comment>
   </data>
@@ -308,7 +308,7 @@ Please ensure that the file is not empty.</value>
     <value>The selected path for is not suitable to save vocabulary books. Do not use optical disk drives or system folders here.</value>
   </data>
   <data name="VhfPathNotFound" xml:space="preserve">
-    <value>The folder for vocabulary books was not found at {0}. Vocup will replace your configuration with the default documents directory. You change that in the settings at any time.</value>
+    <value>The folder for vocabulary books was not found at {0}. Vocup will replace your configuration with the default documents directory. You can change that in the settings at any time.</value>
     <comment>{0}: Path</comment>
   </data>
   <data name="VhfPathNotFoundT" xml:space="preserve">
@@ -330,7 +330,7 @@ Please ensure that the file is not empty.</value>
     <value>The selected path for is not suitable to save practice results. Do not use optical disk drives or system folders here.</value>
   </data>
   <data name="VhrPathNotFound" xml:space="preserve">
-    <value>The folder for practice results was not found at {0}. Vocup will replace your configuration with the default application data directory. You change that in the settings at any time.</value>
+    <value>The folder for practice results was not found at {0}. Vocup will replace your configuration with the default application data directory. You can change that in the settings at any time.</value>
   </data>
   <data name="VhrPathNotFoundT" xml:space="preserve">
     <value>Folder for practice results not found</value>

--- a/src/Vocup/Properties/Words.nl.resx
+++ b/src/Vocup/Properties/Words.nl.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AddVocabularyBooks" xml:space="preserve">
-    <value>Taalbestanden toevoegen</value>
+    <value>Woordenboeken toevoegen</value>
   </data>
   <data name="AddWord" xml:space="preserve">
     <value>Nieuw woord toevoegen</value>
@@ -141,13 +141,13 @@
     <comment>{0}: Word, {1}: Synonym</comment>
   </data>
   <data name="CreateVocabularyBook" xml:space="preserve">
-    <value>Nieuw taalbestand maken</value>
+    <value>Nieuw woordenboek maken</value>
   </data>
   <data name="EasterEgg" xml:space="preserve">
     <value>Easter egg</value>
   </data>
   <data name="EditVocabularyBook" xml:space="preserve">
-    <value>Taalbestand aanpassen</value>
+    <value>Woordenboek aanpassen</value>
   </data>
   <data name="EditWord" xml:space="preserve">
     <value>Woord aanpassen</value>
@@ -168,7 +168,7 @@
     <value>Open back-up</value>
   </data>
   <data name="OpenVocabularyBook" xml:space="preserve">
-    <value>Open taalbestand</value>
+    <value>Open woordenboek</value>
   </data>
   <data name="OverallOneWord" xml:space="preserve">
     <value>1 woord in totaal</value>
@@ -181,7 +181,7 @@
     <value>Deels goed</value>
   </data>
   <data name="SaveVocabularyBook" xml:space="preserve">
-    <value>Taalbestand opslaan</value>
+    <value>Woordenboek opslaan</value>
   </data>
   <data name="Site" xml:space="preserve">
     <value>Site</value>
@@ -200,7 +200,7 @@
     <value>Vocup back-up bestand</value>
   </data>
   <data name="VocupVocabularyBookFile" xml:space="preserve">
-    <value>Vocup taalbestand</value>
+    <value>Vocup woordenboek</value>
   </data>
   <data name="Wrong" xml:space="preserve">
     <value>Fout</value>

--- a/src/Vocup/Properties/Words.nl.resx
+++ b/src/Vocup/Properties/Words.nl.resx
@@ -1,0 +1,208 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AddVocabularyBooks" xml:space="preserve">
+    <value>Taalbestanden toevoegen</value>
+  </data>
+  <data name="AddWord" xml:space="preserve">
+    <value>Nieuw woord toevoegen</value>
+  </data>
+  <data name="AllWords" xml:space="preserve">
+    <value>Alle woorden</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="Correct" xml:space="preserve">
+    <value>Goed</value>
+  </data>
+  <data name="CorrectWasX" xml:space="preserve">
+    <value>Het goede antwoord: {0}</value>
+    <comment>{0}: Word</comment>
+  </data>
+  <data name="CorrectWasXAndY" xml:space="preserve">
+    <value>Het goede antwoord: {0} en {1}</value>
+    <comment>{0}: Word, {1}: Synonym</comment>
+  </data>
+  <data name="CreateVocabularyBook" xml:space="preserve">
+    <value>Nieuw taalbestand maken</value>
+  </data>
+  <data name="EasterEgg" xml:space="preserve">
+    <value>Easter egg</value>
+  </data>
+  <data name="EditVocabularyBook" xml:space="preserve">
+    <value>Taalbestand aanpassen</value>
+  </data>
+  <data name="EditWord" xml:space="preserve">
+    <value>Woord aanpassen</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>Exporteren</value>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Klaar</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>Importeren</value>
+  </data>
+  <data name="Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="OpenBackup" xml:space="preserve">
+    <value>Open back-up</value>
+  </data>
+  <data name="OpenVocabularyBook" xml:space="preserve">
+    <value>Open taalbestand</value>
+  </data>
+  <data name="OverallOneWord" xml:space="preserve">
+    <value>1 woord in totaal</value>
+  </data>
+  <data name="OverallXWords" xml:space="preserve">
+    <value>{0} woorden in totaal</value>
+    <comment>{0}: Count</comment>
+  </data>
+  <data name="PartlyCorrect" xml:space="preserve">
+    <value>Deels goed</value>
+  </data>
+  <data name="SaveVocabularyBook" xml:space="preserve">
+    <value>Taalbestand opslaan</value>
+  </data>
+  <data name="Site" xml:space="preserve">
+    <value>Site</value>
+  </data>
+  <data name="SpecialChars" xml:space="preserve">
+    <value>Speciale tekens</value>
+  </data>
+  <data name="Synonym" xml:space="preserve">
+    <value>Synoniem</value>
+  </data>
+  <data name="Vocup" xml:space="preserve">
+    <value>Vocup</value>
+    <comment>Localizable program name</comment>
+  </data>
+  <data name="VocupBackupFile" xml:space="preserve">
+    <value>Vocup back-up bestand</value>
+  </data>
+  <data name="VocupVocabularyBookFile" xml:space="preserve">
+    <value>Vocup taalbestand</value>
+  </data>
+  <data name="Wrong" xml:space="preserve">
+    <value>Fout</value>
+  </data>
+</root>


### PR DESCRIPTION
Added Dutch UI language and fixed typos in the English resources. Also resized the right column in the grid on the main form to allow a better fit for the Dutch translated words.
Fixes #46  