### PR TITLE
Dark Mode

### DIFF
--- a/src/Vocup.WinForms/Forms/PracticeDialog.Designer.cs
+++ b/src/Vocup.WinForms/Forms/PracticeDialog.Designer.cs
@@ -30,308 +30,304 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PracticeDialog));
-            this.TbForeignLangSynonym = new System.Windows.Forms.TextBox();
-            this.TbForeignLang = new System.Windows.Forms.TextBox();
-            this.TbMotherTongue = new System.Windows.Forms.TextBox();
-            this.LbForeignLangSynonym = new System.Windows.Forms.Label();
-            this.LbForeignLang = new System.Windows.Forms.Label();
-            this.LbMotherTongue = new System.Windows.Forms.Label();
-            this.GroupStatistics = new System.Windows.Forms.GroupBox();
-            this.TbWrongCount = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
-            this.TbPartlyCorrectCount = new System.Windows.Forms.TextBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.TbCorrectCount = new System.Windows.Forms.TextBox();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.TbPracticedCount = new System.Windows.Forms.TextBox();
-            this.TbUnpracticedCount = new System.Windows.Forms.TextBox();
-            this.TbPracticeCount = new System.Windows.Forms.TextBox();
-            this.PbPracticeProgress = new System.Windows.Forms.ProgressBar();
-            this.BtnCancel = new System.Windows.Forms.Button();
-            this.BtnContinue = new System.Windows.Forms.Button();
-            this.TbCorrectAnswer = new System.Windows.Forms.TextBox();
-            this.BtnSpecialChar = new System.Windows.Forms.Button();
-            this.RbPartlyCorrect = new System.Windows.Forms.RadioButton();
-            this.RbWrong = new System.Windows.Forms.RadioButton();
-            this.RbCorrect = new System.Windows.Forms.RadioButton();
-            this.GroupUserEvaluation = new System.Windows.Forms.GroupBox();
-            this.TableLayout = new System.Windows.Forms.TableLayoutPanel();
-            this.PanelMotherTongue = new System.Windows.Forms.Panel();
-            this.PanelForeignLang = new System.Windows.Forms.Panel();
-            this.PanelForeignLangSynonym = new System.Windows.Forms.Panel();
-            this.GroupStatistics.SuspendLayout();
-            this.GroupUserEvaluation.SuspendLayout();
-            this.TableLayout.SuspendLayout();
-            this.PanelMotherTongue.SuspendLayout();
-            this.PanelForeignLang.SuspendLayout();
-            this.PanelForeignLangSynonym.SuspendLayout();
-            this.SuspendLayout();
+            TbForeignLangSynonym = new System.Windows.Forms.TextBox();
+            TbForeignLang = new System.Windows.Forms.TextBox();
+            TbMotherTongue = new System.Windows.Forms.TextBox();
+            LbForeignLangSynonym = new System.Windows.Forms.Label();
+            LbForeignLang = new System.Windows.Forms.Label();
+            LbMotherTongue = new System.Windows.Forms.Label();
+            GroupStatistics = new System.Windows.Forms.GroupBox();
+            TbWrongCount = new System.Windows.Forms.TextBox();
+            label6 = new System.Windows.Forms.Label();
+            TbPartlyCorrectCount = new System.Windows.Forms.TextBox();
+            label5 = new System.Windows.Forms.Label();
+            label4 = new System.Windows.Forms.Label();
+            TbCorrectCount = new System.Windows.Forms.TextBox();
+            label3 = new System.Windows.Forms.Label();
+            label2 = new System.Windows.Forms.Label();
+            label1 = new System.Windows.Forms.Label();
+            TbPracticedCount = new System.Windows.Forms.TextBox();
+            TbUnpracticedCount = new System.Windows.Forms.TextBox();
+            TbPracticeCount = new System.Windows.Forms.TextBox();
+            PbPracticeProgress = new System.Windows.Forms.ProgressBar();
+            BtnCancel = new System.Windows.Forms.Button();
+            BtnContinue = new System.Windows.Forms.Button();
+            TbCorrectAnswer = new System.Windows.Forms.TextBox();
+            BtnSpecialChar = new System.Windows.Forms.Button();
+            RbPartlyCorrect = new System.Windows.Forms.RadioButton();
+            RbWrong = new System.Windows.Forms.RadioButton();
+            RbCorrect = new System.Windows.Forms.RadioButton();
+            GroupUserEvaluation = new System.Windows.Forms.GroupBox();
+            TableLayout = new System.Windows.Forms.TableLayoutPanel();
+            PanelMotherTongue = new System.Windows.Forms.Panel();
+            PanelForeignLang = new System.Windows.Forms.Panel();
+            PanelForeignLangSynonym = new System.Windows.Forms.Panel();
+            GroupStatistics.SuspendLayout();
+            GroupUserEvaluation.SuspendLayout();
+            TableLayout.SuspendLayout();
+            PanelMotherTongue.SuspendLayout();
+            PanelForeignLang.SuspendLayout();
+            PanelForeignLangSynonym.SuspendLayout();
+            SuspendLayout();
             // 
             // TbForeignLangSynonym
             // 
-            resources.ApplyResources(this.TbForeignLangSynonym, "TbForeignLangSynonym");
-            this.TbForeignLangSynonym.Name = "TbForeignLangSynonym";
-            this.TbForeignLangSynonym.Enter += new System.EventHandler(this.TextBox_Enter);
+            resources.ApplyResources(TbForeignLangSynonym, "TbForeignLangSynonym");
+            TbForeignLangSynonym.Name = "TbForeignLangSynonym";
+            TbForeignLangSynonym.Enter += TextBox_Enter;
             // 
             // TbForeignLang
             // 
-            resources.ApplyResources(this.TbForeignLang, "TbForeignLang");
-            this.TbForeignLang.Name = "TbForeignLang";
-            this.TbForeignLang.Enter += new System.EventHandler(this.TextBox_Enter);
+            resources.ApplyResources(TbForeignLang, "TbForeignLang");
+            TbForeignLang.Name = "TbForeignLang";
+            TbForeignLang.Enter += TextBox_Enter;
             // 
             // TbMotherTongue
             // 
-            resources.ApplyResources(this.TbMotherTongue, "TbMotherTongue");
-            this.TbMotherTongue.Name = "TbMotherTongue";
-            this.TbMotherTongue.Enter += new System.EventHandler(this.TextBox_Enter);
+            resources.ApplyResources(TbMotherTongue, "TbMotherTongue");
+            TbMotherTongue.Name = "TbMotherTongue";
+            TbMotherTongue.Enter += TextBox_Enter;
             // 
             // LbForeignLangSynonym
             // 
-            resources.ApplyResources(this.LbForeignLangSynonym, "LbForeignLangSynonym");
-            this.LbForeignLangSynonym.Name = "LbForeignLangSynonym";
+            resources.ApplyResources(LbForeignLangSynonym, "LbForeignLangSynonym");
+            LbForeignLangSynonym.Name = "LbForeignLangSynonym";
             // 
             // LbForeignLang
             // 
-            resources.ApplyResources(this.LbForeignLang, "LbForeignLang");
-            this.LbForeignLang.Name = "LbForeignLang";
+            resources.ApplyResources(LbForeignLang, "LbForeignLang");
+            LbForeignLang.Name = "LbForeignLang";
             // 
             // LbMotherTongue
             // 
-            resources.ApplyResources(this.LbMotherTongue, "LbMotherTongue");
-            this.LbMotherTongue.Name = "LbMotherTongue";
+            resources.ApplyResources(LbMotherTongue, "LbMotherTongue");
+            LbMotherTongue.Name = "LbMotherTongue";
             // 
             // GroupStatistics
             // 
-            resources.ApplyResources(this.GroupStatistics, "GroupStatistics");
-            this.GroupStatistics.Controls.Add(this.TbWrongCount);
-            this.GroupStatistics.Controls.Add(this.label6);
-            this.GroupStatistics.Controls.Add(this.TbPartlyCorrectCount);
-            this.GroupStatistics.Controls.Add(this.label5);
-            this.GroupStatistics.Controls.Add(this.label4);
-            this.GroupStatistics.Controls.Add(this.TbCorrectCount);
-            this.GroupStatistics.Controls.Add(this.label3);
-            this.GroupStatistics.Controls.Add(this.label2);
-            this.GroupStatistics.Controls.Add(this.label1);
-            this.GroupStatistics.Controls.Add(this.TbPracticedCount);
-            this.GroupStatistics.Controls.Add(this.TbUnpracticedCount);
-            this.GroupStatistics.Controls.Add(this.TbPracticeCount);
-            this.GroupStatistics.Controls.Add(this.PbPracticeProgress);
-            this.GroupStatistics.Name = "GroupStatistics";
-            this.GroupStatistics.TabStop = false;
+            resources.ApplyResources(GroupStatistics, "GroupStatistics");
+            GroupStatistics.Controls.Add(TbWrongCount);
+            GroupStatistics.Controls.Add(label6);
+            GroupStatistics.Controls.Add(TbPartlyCorrectCount);
+            GroupStatistics.Controls.Add(label5);
+            GroupStatistics.Controls.Add(label4);
+            GroupStatistics.Controls.Add(TbCorrectCount);
+            GroupStatistics.Controls.Add(label3);
+            GroupStatistics.Controls.Add(label2);
+            GroupStatistics.Controls.Add(label1);
+            GroupStatistics.Controls.Add(TbPracticedCount);
+            GroupStatistics.Controls.Add(TbUnpracticedCount);
+            GroupStatistics.Controls.Add(TbPracticeCount);
+            GroupStatistics.Controls.Add(PbPracticeProgress);
+            GroupStatistics.Name = "GroupStatistics";
+            GroupStatistics.TabStop = false;
             // 
             // TbWrongCount
             // 
-            this.TbWrongCount.BackColor = System.Drawing.Color.Pink;
-            this.TbWrongCount.ForeColor = System.Drawing.SystemColors.WindowText;
-            resources.ApplyResources(this.TbWrongCount, "TbWrongCount");
-            this.TbWrongCount.Name = "TbWrongCount";
-            this.TbWrongCount.ReadOnly = true;
-            this.TbWrongCount.TabStop = false;
+            TbWrongCount.BackColor = System.Drawing.Color.Pink;
+            resources.ApplyResources(TbWrongCount, "TbWrongCount");
+            TbWrongCount.Name = "TbWrongCount";
+            TbWrongCount.ReadOnly = true;
+            TbWrongCount.TabStop = false;
             // 
             // label6
             // 
-            resources.ApplyResources(this.label6, "label6");
-            this.label6.Name = "label6";
+            resources.ApplyResources(label6, "label6");
+            label6.Name = "label6";
             // 
             // TbPartlyCorrectCount
             // 
-            this.TbPartlyCorrectCount.BackColor = System.Drawing.Color.Gold;
-            this.TbPartlyCorrectCount.ForeColor = System.Drawing.SystemColors.WindowText;
-            resources.ApplyResources(this.TbPartlyCorrectCount, "TbPartlyCorrectCount");
-            this.TbPartlyCorrectCount.Name = "TbPartlyCorrectCount";
-            this.TbPartlyCorrectCount.ReadOnly = true;
-            this.TbPartlyCorrectCount.TabStop = false;
+            TbPartlyCorrectCount.BackColor = System.Drawing.Color.Gold;
+            resources.ApplyResources(TbPartlyCorrectCount, "TbPartlyCorrectCount");
+            TbPartlyCorrectCount.Name = "TbPartlyCorrectCount";
+            TbPartlyCorrectCount.ReadOnly = true;
+            TbPartlyCorrectCount.TabStop = false;
             // 
             // label5
             // 
-            resources.ApplyResources(this.label5, "label5");
-            this.label5.Name = "label5";
+            resources.ApplyResources(label5, "label5");
+            label5.Name = "label5";
             // 
             // label4
             // 
-            resources.ApplyResources(this.label4, "label4");
-            this.label4.Name = "label4";
+            resources.ApplyResources(label4, "label4");
+            label4.Name = "label4";
             // 
             // TbCorrectCount
             // 
-            this.TbCorrectCount.BackColor = System.Drawing.Color.LightGreen;
-            this.TbCorrectCount.ForeColor = System.Drawing.SystemColors.WindowText;
-            resources.ApplyResources(this.TbCorrectCount, "TbCorrectCount");
-            this.TbCorrectCount.Name = "TbCorrectCount";
-            this.TbCorrectCount.ReadOnly = true;
-            this.TbCorrectCount.TabStop = false;
+            TbCorrectCount.BackColor = System.Drawing.Color.LightGreen;
+            resources.ApplyResources(TbCorrectCount, "TbCorrectCount");
+            TbCorrectCount.Name = "TbCorrectCount";
+            TbCorrectCount.ReadOnly = true;
+            TbCorrectCount.TabStop = false;
             // 
             // label3
             // 
-            resources.ApplyResources(this.label3, "label3");
-            this.label3.Name = "label3";
+            resources.ApplyResources(label3, "label3");
+            label3.Name = "label3";
             // 
             // label2
             // 
-            resources.ApplyResources(this.label2, "label2");
-            this.label2.Name = "label2";
+            resources.ApplyResources(label2, "label2");
+            label2.Name = "label2";
             // 
             // label1
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
+            resources.ApplyResources(label1, "label1");
+            label1.Name = "label1";
             // 
             // TbPracticedCount
             // 
-            resources.ApplyResources(this.TbPracticedCount, "TbPracticedCount");
-            this.TbPracticedCount.Name = "TbPracticedCount";
-            this.TbPracticedCount.ReadOnly = true;
-            this.TbPracticedCount.TabStop = false;
+            resources.ApplyResources(TbPracticedCount, "TbPracticedCount");
+            TbPracticedCount.Name = "TbPracticedCount";
+            TbPracticedCount.ReadOnly = true;
+            TbPracticedCount.TabStop = false;
             // 
             // TbUnpracticedCount
             // 
-            resources.ApplyResources(this.TbUnpracticedCount, "TbUnpracticedCount");
-            this.TbUnpracticedCount.Name = "TbUnpracticedCount";
-            this.TbUnpracticedCount.ReadOnly = true;
-            this.TbUnpracticedCount.TabStop = false;
+            resources.ApplyResources(TbUnpracticedCount, "TbUnpracticedCount");
+            TbUnpracticedCount.Name = "TbUnpracticedCount";
+            TbUnpracticedCount.ReadOnly = true;
+            TbUnpracticedCount.TabStop = false;
             // 
             // TbPracticeCount
             // 
-            resources.ApplyResources(this.TbPracticeCount, "TbPracticeCount");
-            this.TbPracticeCount.Name = "TbPracticeCount";
-            this.TbPracticeCount.ReadOnly = true;
-            this.TbPracticeCount.TabStop = false;
+            resources.ApplyResources(TbPracticeCount, "TbPracticeCount");
+            TbPracticeCount.Name = "TbPracticeCount";
+            TbPracticeCount.ReadOnly = true;
+            TbPracticeCount.TabStop = false;
             // 
             // PbPracticeProgress
             // 
-            resources.ApplyResources(this.PbPracticeProgress, "PbPracticeProgress");
-            this.PbPracticeProgress.Name = "PbPracticeProgress";
-            this.PbPracticeProgress.Step = 100;
-            this.PbPracticeProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            resources.ApplyResources(PbPracticeProgress, "PbPracticeProgress");
+            PbPracticeProgress.Name = "PbPracticeProgress";
+            PbPracticeProgress.Step = 100;
+            PbPracticeProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             // 
             // BtnCancel
             // 
-            resources.ApplyResources(this.BtnCancel, "BtnCancel");
-            this.BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.BtnCancel.Name = "BtnCancel";
-            this.BtnCancel.UseVisualStyleBackColor = true;
+            resources.ApplyResources(BtnCancel, "BtnCancel");
+            BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            BtnCancel.Name = "BtnCancel";
+            BtnCancel.UseVisualStyleBackColor = true;
             // 
             // BtnContinue
             // 
-            resources.ApplyResources(this.BtnContinue, "BtnContinue");
-            this.BtnContinue.Name = "BtnContinue";
-            this.BtnContinue.UseVisualStyleBackColor = true;
-            this.BtnContinue.Click += new System.EventHandler(this.BtnContinue_Click);
+            resources.ApplyResources(BtnContinue, "BtnContinue");
+            BtnContinue.Name = "BtnContinue";
+            BtnContinue.UseVisualStyleBackColor = true;
+            BtnContinue.Click += BtnContinue_Click;
             // 
             // TbCorrectAnswer
             // 
-            this.TbCorrectAnswer.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.TableLayout.SetColumnSpan(this.TbCorrectAnswer, 2);
-            resources.ApplyResources(this.TbCorrectAnswer, "TbCorrectAnswer");
-            this.TbCorrectAnswer.Name = "TbCorrectAnswer";
-            this.TbCorrectAnswer.ReadOnly = true;
-            this.TbCorrectAnswer.TabStop = false;
+            TbCorrectAnswer.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            TableLayout.SetColumnSpan(TbCorrectAnswer, 2);
+            resources.ApplyResources(TbCorrectAnswer, "TbCorrectAnswer");
+            TbCorrectAnswer.Name = "TbCorrectAnswer";
+            TbCorrectAnswer.ReadOnly = true;
+            TbCorrectAnswer.TabStop = false;
             // 
             // BtnSpecialChar
             // 
-            resources.ApplyResources(this.BtnSpecialChar, "BtnSpecialChar");
-            this.BtnSpecialChar.Name = "BtnSpecialChar";
-            this.BtnSpecialChar.UseVisualStyleBackColor = true;
+            resources.ApplyResources(BtnSpecialChar, "BtnSpecialChar");
+            BtnSpecialChar.Name = "BtnSpecialChar";
+            BtnSpecialChar.UseVisualStyleBackColor = true;
             // 
             // RbPartlyCorrect
             // 
-            resources.ApplyResources(this.RbPartlyCorrect, "RbPartlyCorrect");
-            this.RbPartlyCorrect.BackColor = System.Drawing.Color.Transparent;
-            this.RbPartlyCorrect.Name = "RbPartlyCorrect";
-            this.RbPartlyCorrect.TabStop = true;
-            this.RbPartlyCorrect.UseVisualStyleBackColor = false;
+            resources.ApplyResources(RbPartlyCorrect, "RbPartlyCorrect");
+            RbPartlyCorrect.BackColor = System.Drawing.Color.Transparent;
+            RbPartlyCorrect.Name = "RbPartlyCorrect";
+            RbPartlyCorrect.TabStop = true;
+            RbPartlyCorrect.UseVisualStyleBackColor = false;
             // 
             // RbWrong
             // 
-            resources.ApplyResources(this.RbWrong, "RbWrong");
-            this.RbWrong.BackColor = System.Drawing.Color.Transparent;
-            this.RbWrong.Name = "RbWrong";
-            this.RbWrong.TabStop = true;
-            this.RbWrong.UseVisualStyleBackColor = false;
+            resources.ApplyResources(RbWrong, "RbWrong");
+            RbWrong.BackColor = System.Drawing.Color.Transparent;
+            RbWrong.Name = "RbWrong";
+            RbWrong.TabStop = true;
+            RbWrong.UseVisualStyleBackColor = false;
             // 
             // RbCorrect
             // 
-            resources.ApplyResources(this.RbCorrect, "RbCorrect");
-            this.RbCorrect.BackColor = System.Drawing.Color.Transparent;
-            this.RbCorrect.Checked = true;
-            this.RbCorrect.Name = "RbCorrect";
-            this.RbCorrect.TabStop = true;
-            this.RbCorrect.UseVisualStyleBackColor = false;
+            resources.ApplyResources(RbCorrect, "RbCorrect");
+            RbCorrect.BackColor = System.Drawing.Color.Transparent;
+            RbCorrect.Checked = true;
+            RbCorrect.Name = "RbCorrect";
+            RbCorrect.TabStop = true;
+            RbCorrect.UseVisualStyleBackColor = false;
             // 
             // GroupUserEvaluation
             // 
-            resources.ApplyResources(this.GroupUserEvaluation, "GroupUserEvaluation");
-            this.GroupUserEvaluation.Controls.Add(this.RbCorrect);
-            this.GroupUserEvaluation.Controls.Add(this.RbWrong);
-            this.GroupUserEvaluation.Controls.Add(this.RbPartlyCorrect);
-            this.GroupUserEvaluation.Name = "GroupUserEvaluation";
-            this.GroupUserEvaluation.TabStop = false;
+            resources.ApplyResources(GroupUserEvaluation, "GroupUserEvaluation");
+            GroupUserEvaluation.Controls.Add(RbCorrect);
+            GroupUserEvaluation.Controls.Add(RbWrong);
+            GroupUserEvaluation.Controls.Add(RbPartlyCorrect);
+            GroupUserEvaluation.Name = "GroupUserEvaluation";
+            GroupUserEvaluation.TabStop = false;
             // 
             // TableLayout
             // 
-            resources.ApplyResources(this.TableLayout, "TableLayout");
-            this.TableLayout.Controls.Add(this.PanelMotherTongue, 0, 0);
-            this.TableLayout.Controls.Add(this.PanelForeignLang, 1, 0);
-            this.TableLayout.Controls.Add(this.TbCorrectAnswer, 0, 2);
-            this.TableLayout.Controls.Add(this.PanelForeignLangSynonym, 1, 1);
-            this.TableLayout.Name = "TableLayout";
+            resources.ApplyResources(TableLayout, "TableLayout");
+            TableLayout.Controls.Add(PanelMotherTongue, 0, 0);
+            TableLayout.Controls.Add(PanelForeignLang, 1, 0);
+            TableLayout.Controls.Add(TbCorrectAnswer, 0, 2);
+            TableLayout.Controls.Add(PanelForeignLangSynonym, 1, 1);
+            TableLayout.Name = "TableLayout";
             // 
             // PanelMotherTongue
             // 
-            this.PanelMotherTongue.Controls.Add(this.LbMotherTongue);
-            this.PanelMotherTongue.Controls.Add(this.TbMotherTongue);
-            resources.ApplyResources(this.PanelMotherTongue, "PanelMotherTongue");
-            this.PanelMotherTongue.Name = "PanelMotherTongue";
-            this.TableLayout.SetRowSpan(this.PanelMotherTongue, 2);
+            PanelMotherTongue.Controls.Add(LbMotherTongue);
+            PanelMotherTongue.Controls.Add(TbMotherTongue);
+            resources.ApplyResources(PanelMotherTongue, "PanelMotherTongue");
+            PanelMotherTongue.Name = "PanelMotherTongue";
+            TableLayout.SetRowSpan(PanelMotherTongue, 2);
             // 
             // PanelForeignLang
             // 
-            this.PanelForeignLang.Controls.Add(this.LbForeignLang);
-            this.PanelForeignLang.Controls.Add(this.TbForeignLang);
-            resources.ApplyResources(this.PanelForeignLang, "PanelForeignLang");
-            this.PanelForeignLang.Name = "PanelForeignLang";
+            PanelForeignLang.Controls.Add(LbForeignLang);
+            PanelForeignLang.Controls.Add(TbForeignLang);
+            resources.ApplyResources(PanelForeignLang, "PanelForeignLang");
+            PanelForeignLang.Name = "PanelForeignLang";
             // 
             // PanelForeignLangSynonym
             // 
-            this.PanelForeignLangSynonym.Controls.Add(this.TbForeignLangSynonym);
-            this.PanelForeignLangSynonym.Controls.Add(this.LbForeignLangSynonym);
-            resources.ApplyResources(this.PanelForeignLangSynonym, "PanelForeignLangSynonym");
-            this.PanelForeignLangSynonym.Name = "PanelForeignLangSynonym";
+            PanelForeignLangSynonym.Controls.Add(TbForeignLangSynonym);
+            PanelForeignLangSynonym.Controls.Add(LbForeignLangSynonym);
+            resources.ApplyResources(PanelForeignLangSynonym, "PanelForeignLangSynonym");
+            PanelForeignLangSynonym.Name = "PanelForeignLangSynonym";
             // 
             // PracticeDialog
             // 
-            this.AcceptButton = this.BtnContinue;
+            AcceptButton = BtnContinue;
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.BtnCancel;
-            this.Controls.Add(this.TableLayout);
-            this.Controls.Add(this.BtnCancel);
-            this.Controls.Add(this.BtnSpecialChar);
-            this.Controls.Add(this.BtnContinue);
-            this.Controls.Add(this.GroupUserEvaluation);
-            this.Controls.Add(this.GroupStatistics);
-            this.Name = "PracticeDialog";
-            this.ShowInTaskbar = false;
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form_FormClosing);
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Form_FormClosed);
-            this.Load += new System.EventHandler(this.Form_Load);
-            this.GroupStatistics.ResumeLayout(false);
-            this.GroupStatistics.PerformLayout();
-            this.GroupUserEvaluation.ResumeLayout(false);
-            this.GroupUserEvaluation.PerformLayout();
-            this.TableLayout.ResumeLayout(false);
-            this.TableLayout.PerformLayout();
-            this.PanelMotherTongue.ResumeLayout(false);
-            this.PanelMotherTongue.PerformLayout();
-            this.PanelForeignLang.ResumeLayout(false);
-            this.PanelForeignLang.PerformLayout();
-            this.PanelForeignLangSynonym.ResumeLayout(false);
-            this.PanelForeignLangSynonym.PerformLayout();
-            this.ResumeLayout(false);
-
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = BtnCancel;
+            Controls.Add(TableLayout);
+            Controls.Add(BtnCancel);
+            Controls.Add(BtnSpecialChar);
+            Controls.Add(BtnContinue);
+            Controls.Add(GroupUserEvaluation);
+            Controls.Add(GroupStatistics);
+            Name = "PracticeDialog";
+            ShowInTaskbar = false;
+            FormClosing += Form_FormClosing;
+            FormClosed += Form_FormClosed;
+            Load += Form_Load;
+            GroupStatistics.ResumeLayout(false);
+            GroupStatistics.PerformLayout();
+            GroupUserEvaluation.ResumeLayout(false);
+            GroupUserEvaluation.PerformLayout();
+            TableLayout.ResumeLayout(false);
+            TableLayout.PerformLayout();
+            PanelMotherTongue.ResumeLayout(false);
+            PanelMotherTongue.PerformLayout();
+            PanelForeignLang.ResumeLayout(false);
+            PanelForeignLang.PerformLayout();
+            PanelForeignLangSynonym.ResumeLayout(false);
+            PanelForeignLangSynonym.PerformLayout();
+            ResumeLayout(false);
         }
 
         #endregion

--- a/src/Vocup.WinForms/Forms/PracticeDialog.cs
+++ b/src/Vocup.WinForms/Forms/PracticeDialog.cs
@@ -14,6 +14,10 @@ namespace Vocup.Forms;
 public partial class PracticeDialog : Form
 {
     private const int userEvaluationHeight = 38;
+    private readonly Color InputHighlightBackColor;
+    private readonly Color CorrectFeedbackBackColor;
+    private readonly Color PartlyCorrectFeedbackBackColor;
+    private readonly Color WrongFeedbackBackColor;
 
     private readonly VocabularyBook book;
     private readonly List<VocabularyWordPractice> practiceList;
@@ -33,6 +37,24 @@ public partial class PracticeDialog : Form
         InitializeComponent();
 
         Icon = Icon.FromHandle(Icons.LightningBolt.GetHicon());
+
+        InputHighlightBackColor = Color.FromArgb(255, 255, 150);
+        CorrectFeedbackBackColor = Color.FromArgb(144, 238, 144);
+        PartlyCorrectFeedbackBackColor = Color.FromArgb(255, 215, 0);
+        WrongFeedbackBackColor = Color.FromArgb(255, 192, 203);
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (Application.ColorMode == SystemColorMode.Dark)
+        {
+            InputHighlightBackColor = Color.FromArgb(127, 127, 75);
+            CorrectFeedbackBackColor = Color.FromArgb(0, 100, 0);
+            PartlyCorrectFeedbackBackColor = Color.FromArgb(127, 106, 0);
+            WrongFeedbackBackColor = Color.FromArgb(127, 0, 0);
+            TbCorrectCount.BackColor = Color.DarkGreen;
+            TbPartlyCorrectCount.BackColor = Color.DarkGoldenrod;
+            TbWrongCount.BackColor = Color.DarkRed;
+        }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         evaluator = new Evaluator
         {
@@ -182,7 +204,7 @@ public partial class PracticeDialog : Form
             TbMotherTongue.BackColor = DefaultBackColor;
             TbForeignLang.Text = "";
             TbForeignLang.ReadOnly = false;
-            TbForeignLang.BackColor = Color.FromArgb(250, 250, 150);
+            TbForeignLang.BackColor = InputHighlightBackColor;
             TbForeignLangSynonym.Text = "";
             if (string.IsNullOrWhiteSpace(currentWord.ForeignLangSynonym))
             {
@@ -192,7 +214,7 @@ public partial class PracticeDialog : Form
             else
             {
                 TbForeignLangSynonym.ReadOnly = false;
-                TbForeignLangSynonym.BackColor = Color.FromArgb(250, 250, 150);
+                TbForeignLangSynonym.BackColor = InputHighlightBackColor;
             }
             TbForeignLang.Select();
         }
@@ -208,7 +230,7 @@ public partial class PracticeDialog : Form
             TbForeignLang.ReadOnly = true;
             TbForeignLang.BackColor = DefaultBackColor;
             TbForeignLangSynonym.ReadOnly = true;
-            TbMotherTongue.BackColor = Color.FromArgb(250, 250, 150);
+            TbMotherTongue.BackColor = InputHighlightBackColor;
             TbMotherTongue.Select();
         }
 
@@ -235,19 +257,19 @@ public partial class PracticeDialog : Form
         {
             if (string.IsNullOrWhiteSpace(currentWord.ForeignLangSynonym))
             {
-                inputs = new[] { TbForeignLang.Text.Trim() };
-                results = new[] { currentWord.ForeignLang };
+                inputs = [TbForeignLang.Text.Trim()];
+                results = [currentWord.ForeignLang];
             }
             else
             {
-                inputs = new[] { TbForeignLang.Text.Trim(), TbForeignLangSynonym.Text.Trim() };
-                results = new[] { currentWord.ForeignLang, currentWord.ForeignLangSynonym };
+                inputs = [TbForeignLang.Text.Trim(), TbForeignLangSynonym.Text.Trim()];
+                results = [currentWord.ForeignLang, currentWord.ForeignLangSynonym];
             }
         }
         else // PracticeMode.AskForMotherTongue
         {
-            inputs = new[] { TbMotherTongue.Text.Trim() };
-            results = new[] { currentWord.MotherTongue };
+            inputs = [TbMotherTongue.Text.Trim()];
+            results = [currentWord.MotherTongue];
         }
 
         return evaluator.GetResult(results, inputs);
@@ -278,7 +300,7 @@ public partial class PracticeDialog : Form
             if (!Program.Settings.UserEvaluates)
             {
                 TbCorrectAnswer.Text = Words.Correct + "!";
-                TbCorrectAnswer.BackColor = Color.FromArgb(144, 238, 144);
+                TbCorrectAnswer.BackColor = CorrectFeedbackBackColor;
                 sound = Sounds.sound_correct;
             }
         }
@@ -290,7 +312,7 @@ public partial class PracticeDialog : Form
             if (!Program.Settings.UserEvaluates)
             {
                 TbCorrectAnswer.Text = $"{Words.PartlyCorrect}! ({GetEvaluationAnswer()})";
-                TbCorrectAnswer.BackColor = Color.FromArgb(255, 215, 0);
+                TbCorrectAnswer.BackColor = PartlyCorrectFeedbackBackColor;
                 sound = Sounds.sound_correct;
             }
         }
@@ -302,7 +324,7 @@ public partial class PracticeDialog : Form
             if (!Program.Settings.UserEvaluates)
             {
                 TbCorrectAnswer.Text = $"{Words.Wrong}! ({GetEvaluationAnswer()})";
-                TbCorrectAnswer.BackColor = Color.FromArgb(255, 192, 203);
+                TbCorrectAnswer.BackColor = WrongFeedbackBackColor;
                 sound = Sounds.sound_wrong;
             }
         }

--- a/src/Vocup.WinForms/Forms/PracticeDialog.resx
+++ b/src/Vocup.WinForms/Forms/PracticeDialog.resx
@@ -1,4 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/src/Vocup.WinForms/Forms/PracticeResultList.cs
+++ b/src/Vocup.WinForms/Forms/PracticeResultList.cs
@@ -10,6 +10,10 @@ namespace Vocup.Forms;
 
 public partial class PracticeResultList : Form
 {
+    private readonly Color CorrectFeedbackBackColor;
+    private readonly Color PartlyCorrectFeedbackBackColor;
+    private readonly Color WrongFeedbackBackColor;
+
     private VocabularyBook book;
     private List<VocabularyWordPractice> practiceList;
 
@@ -22,6 +26,20 @@ public partial class PracticeResultList : Form
     {
         InitializeComponent();
         Icon = Icon.FromHandle(Icons.BarChart.GetHicon());
+
+        CorrectFeedbackBackColor = Color.FromArgb(144, 238, 144);
+        PartlyCorrectFeedbackBackColor = Color.FromArgb(255, 215, 0);
+        WrongFeedbackBackColor = Color.FromArgb(255, 192, 203);
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (Application.ColorMode == SystemColorMode.Dark)
+        {
+            CorrectFeedbackBackColor = Color.FromArgb(0, 100, 0);
+            PartlyCorrectFeedbackBackColor = Color.FromArgb(127, 106, 0);
+            WrongFeedbackBackColor = Color.FromArgb(127, 0, 0);
+        }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 
         this.book = book;
         this.practiceList = practiceList;
@@ -121,9 +139,9 @@ public partial class PracticeResultList : Form
             TbPercentage.BackColor = correctRatio switch
             {
                 // Steps taken from https://de.wikipedia.org/wiki/Vorlage:Punktesystem_der_gymnasialen_Oberstufe
-                >= 0.70 => Color.FromArgb(144, 238, 144), // at least 70% -> green background
-                >= 0.45 => Color.FromArgb(255, 215, 0), // at least 45% -> yellow background
-                _ => Color.FromArgb(255, 192, 203) // less than 45% -> red background
+                >= 0.70 => CorrectFeedbackBackColor, // at least 70% -> green background
+                >= 0.45 => PartlyCorrectFeedbackBackColor, // at least 45% -> yellow background
+                _ => WrongFeedbackBackColor // less than 45% -> red background
             };
 
             TbPercentage.Text = Math.Round(correctRatio * 100) + "%";

--- a/src/Vocup.WinForms/Forms/SettingsDialog.Designer.cs
+++ b/src/Vocup.WinForms/Forms/SettingsDialog.Designer.cs
@@ -163,7 +163,6 @@
             // 
             // TrbWrongRight
             // 
-            TrbWrongRight.BackColor = System.Drawing.Color.White;
             resources.ApplyResources(TrbWrongRight, "TrbWrongRight");
             TrbWrongRight.Minimum = 1;
             TrbWrongRight.Name = "TrbWrongRight";
@@ -173,7 +172,6 @@
             // 
             // TrbUnknown
             // 
-            TrbUnknown.BackColor = System.Drawing.Color.White;
             resources.ApplyResources(TrbUnknown, "TrbUnknown");
             TrbUnknown.Maximum = 8;
             TrbUnknown.Minimum = 1;
@@ -194,7 +192,7 @@
             // 
             // TabGeneral
             // 
-            TabGeneral.BackColor = System.Drawing.Color.White;
+            TabGeneral.BackColor = System.Drawing.SystemColors.Window;
             TabGeneral.Controls.Add(GroupUserInterface);
             TabGeneral.Controls.Add(GroupVocabularyList);
             TabGeneral.Controls.Add(GroupVhrPath);
@@ -327,7 +325,7 @@
             // 
             // TabPractice
             // 
-            TabPractice.BackColor = System.Drawing.Color.White;
+            TabPractice.BackColor = System.Drawing.SystemColors.Window;
             TabPractice.Controls.Add(GroupEvaluation);
             TabPractice.Controls.Add(GroupPracticeUserInterface);
             TabPractice.Controls.Add(GroupNearlyCorrect);
@@ -441,7 +439,7 @@
             // 
             // TabPracticeSelect
             // 
-            TabPracticeSelect.BackColor = System.Drawing.Color.White;
+            TabPracticeSelect.BackColor = System.Drawing.SystemColors.Window;
             TabPracticeSelect.Controls.Add(BtnResetPracticeSelect);
             TabPracticeSelect.Controls.Add(GroupSelectionMix);
             TabPracticeSelect.Controls.Add(GroupRepetitions);
@@ -569,7 +567,6 @@
             // 
             // TrbRepetitions
             // 
-            TrbRepetitions.BackColor = System.Drawing.Color.White;
             TrbRepetitions.LargeChange = 1;
             resources.ApplyResources(TrbRepetitions, "TrbRepetitions");
             TrbRepetitions.Maximum = 6;

--- a/src/Vocup.WinForms/Forms/SettingsDialog.Designer.cs
+++ b/src/Vocup.WinForms/Forms/SettingsDialog.Designer.cs
@@ -29,594 +29,606 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
-            this.BtnOk = new System.Windows.Forms.Button();
-            this.BtnCancel = new System.Windows.Forms.Button();
-            this.GroupStartScreen = new System.Windows.Forms.GroupBox();
-            this.BtnResetStartScreen = new System.Windows.Forms.Button();
-            this.RbEmptyStart = new System.Windows.Forms.RadioButton();
-            this.RbRecentFile = new System.Windows.Forms.RadioButton();
-            this.TrbWrongRight = new System.Windows.Forms.TrackBar();
-            this.TrbUnknown = new System.Windows.Forms.TrackBar();
-            this.TabControlMain = new System.Windows.Forms.TabControl();
-            this.TabGeneral = new System.Windows.Forms.TabPage();
-            this.GroupLanguage = new System.Windows.Forms.GroupBox();
-            this.LbLanguage = new System.Windows.Forms.Label();
-            this.CbLanguage = new System.Windows.Forms.ComboBox();
-            this.GroupVocabularyList = new System.Windows.Forms.GroupBox();
-            this.CbColumnResize = new System.Windows.Forms.CheckBox();
-            this.GroupVhrPath = new System.Windows.Forms.GroupBox();
-            this.BtnVhrPath = new System.Windows.Forms.Button();
-            this.TbVhrPath = new System.Windows.Forms.TextBox();
-            this.GroupVhfPath = new System.Windows.Forms.GroupBox();
-            this.BtnVhfPath = new System.Windows.Forms.Button();
-            this.TbVhfPath = new System.Windows.Forms.TextBox();
-            this.GroupUpdate = new System.Windows.Forms.GroupBox();
-            this.CbDisableInternetServices = new System.Windows.Forms.CheckBox();
-            this.GroupSave = new System.Windows.Forms.GroupBox();
-            this.CbAutoSave = new System.Windows.Forms.CheckBox();
-            this.TabPractice = new System.Windows.Forms.TabPage();
-            this.GroupEvaluation = new System.Windows.Forms.GroupBox();
-            this.CbOptionalExpressions = new System.Windows.Forms.CheckBox();
-            this.CbManualCheck = new System.Windows.Forms.CheckBox();
-            this.CbShowPracticeResult = new System.Windows.Forms.CheckBox();
-            this.GroupUserInterface = new System.Windows.Forms.GroupBox();
-            this.CbAcousticFeedback = new System.Windows.Forms.CheckBox();
-            this.CbSingleContinueButton = new System.Windows.Forms.CheckBox();
-            this.GroupNearlyCorrect = new System.Windows.Forms.GroupBox();
-            this.CbTolerateWhiteSpace = new System.Windows.Forms.CheckBox();
-            this.CbTolerateNoSynonym = new System.Windows.Forms.CheckBox();
-            this.CbTolerateArticle = new System.Windows.Forms.CheckBox();
-            this.CbToleratePunctuationMark = new System.Windows.Forms.CheckBox();
-            this.CbTolerateSpecialChar = new System.Windows.Forms.CheckBox();
-            this.TabPracticeSelect = new System.Windows.Forms.TabPage();
-            this.BtnResetPracticeSelect = new System.Windows.Forms.Button();
-            this.GroupSelectionMix = new System.Windows.Forms.GroupBox();
-            this.LbWronglyPracticed = new System.Windows.Forms.Label();
-            this.LbCorrectlyPracticed = new System.Windows.Forms.Label();
-            this.LbUnpracticed = new System.Windows.Forms.Label();
-            this.LbPercentageUnpracticed = new System.Windows.Forms.Label();
-            this.pictureBox2 = new System.Windows.Forms.PictureBox();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.pictureBox3 = new System.Windows.Forms.PictureBox();
-            this.LbPercentageWrongCorrect = new System.Windows.Forms.Label();
-            this.GroupRepetitions = new System.Windows.Forms.GroupBox();
-            this.LbPracticeCount = new System.Windows.Forms.Label();
-            this.PnlPracticeCount = new System.Windows.Forms.Panel();
-            this.LbTrb6 = new System.Windows.Forms.Label();
-            this.LbTrb2 = new System.Windows.Forms.Label();
-            this.LbTrb5 = new System.Windows.Forms.Label();
-            this.LbTrb3 = new System.Windows.Forms.Label();
-            this.LbTrb4 = new System.Windows.Forms.Label();
-            this.TrbRepetitions = new System.Windows.Forms.TrackBar();
-            this.GroupStartScreen.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.TrbWrongRight)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TrbUnknown)).BeginInit();
-            this.TabControlMain.SuspendLayout();
-            this.TabGeneral.SuspendLayout();
-            this.GroupLanguage.SuspendLayout();
-            this.GroupVocabularyList.SuspendLayout();
-            this.GroupVhrPath.SuspendLayout();
-            this.GroupVhfPath.SuspendLayout();
-            this.GroupUpdate.SuspendLayout();
-            this.GroupSave.SuspendLayout();
-            this.TabPractice.SuspendLayout();
-            this.GroupEvaluation.SuspendLayout();
-            this.GroupUserInterface.SuspendLayout();
-            this.GroupNearlyCorrect.SuspendLayout();
-            this.TabPracticeSelect.SuspendLayout();
-            this.GroupSelectionMix.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
-            this.GroupRepetitions.SuspendLayout();
-            this.PnlPracticeCount.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.TrbRepetitions)).BeginInit();
-            this.SuspendLayout();
+            BtnOk = new System.Windows.Forms.Button();
+            BtnCancel = new System.Windows.Forms.Button();
+            GroupStartScreen = new System.Windows.Forms.GroupBox();
+            BtnResetStartScreen = new System.Windows.Forms.Button();
+            RbEmptyStart = new System.Windows.Forms.RadioButton();
+            RbRecentFile = new System.Windows.Forms.RadioButton();
+            TrbWrongRight = new System.Windows.Forms.TrackBar();
+            TrbUnknown = new System.Windows.Forms.TrackBar();
+            TabControlMain = new System.Windows.Forms.TabControl();
+            TabGeneral = new System.Windows.Forms.TabPage();
+            GroupUserInterface = new System.Windows.Forms.GroupBox();
+            CbColorTheme = new System.Windows.Forms.ComboBox();
+            LbColorTheme = new System.Windows.Forms.Label();
+            LbLanguage = new System.Windows.Forms.Label();
+            CbLanguage = new System.Windows.Forms.ComboBox();
+            GroupVocabularyList = new System.Windows.Forms.GroupBox();
+            CbColumnResize = new System.Windows.Forms.CheckBox();
+            GroupVhrPath = new System.Windows.Forms.GroupBox();
+            BtnVhrPath = new System.Windows.Forms.Button();
+            TbVhrPath = new System.Windows.Forms.TextBox();
+            GroupVhfPath = new System.Windows.Forms.GroupBox();
+            BtnVhfPath = new System.Windows.Forms.Button();
+            TbVhfPath = new System.Windows.Forms.TextBox();
+            GroupUpdate = new System.Windows.Forms.GroupBox();
+            CbDisableInternetServices = new System.Windows.Forms.CheckBox();
+            GroupSave = new System.Windows.Forms.GroupBox();
+            CbAutoSave = new System.Windows.Forms.CheckBox();
+            TabPractice = new System.Windows.Forms.TabPage();
+            GroupEvaluation = new System.Windows.Forms.GroupBox();
+            CbOptionalExpressions = new System.Windows.Forms.CheckBox();
+            CbManualCheck = new System.Windows.Forms.CheckBox();
+            CbShowPracticeResult = new System.Windows.Forms.CheckBox();
+            GroupPracticeUserInterface = new System.Windows.Forms.GroupBox();
+            CbAcousticFeedback = new System.Windows.Forms.CheckBox();
+            CbSingleContinueButton = new System.Windows.Forms.CheckBox();
+            GroupNearlyCorrect = new System.Windows.Forms.GroupBox();
+            CbTolerateWhiteSpace = new System.Windows.Forms.CheckBox();
+            CbTolerateNoSynonym = new System.Windows.Forms.CheckBox();
+            CbTolerateArticle = new System.Windows.Forms.CheckBox();
+            CbToleratePunctuationMark = new System.Windows.Forms.CheckBox();
+            CbTolerateSpecialChar = new System.Windows.Forms.CheckBox();
+            TabPracticeSelect = new System.Windows.Forms.TabPage();
+            BtnResetPracticeSelect = new System.Windows.Forms.Button();
+            GroupSelectionMix = new System.Windows.Forms.GroupBox();
+            LbWronglyPracticed = new System.Windows.Forms.Label();
+            LbCorrectlyPracticed = new System.Windows.Forms.Label();
+            LbUnpracticed = new System.Windows.Forms.Label();
+            LbPercentageUnpracticed = new System.Windows.Forms.Label();
+            pictureBox2 = new System.Windows.Forms.PictureBox();
+            pictureBox1 = new System.Windows.Forms.PictureBox();
+            pictureBox3 = new System.Windows.Forms.PictureBox();
+            LbPercentageWrongCorrect = new System.Windows.Forms.Label();
+            GroupRepetitions = new System.Windows.Forms.GroupBox();
+            LbPracticeCount = new System.Windows.Forms.Label();
+            PnlPracticeCount = new System.Windows.Forms.Panel();
+            LbTrb6 = new System.Windows.Forms.Label();
+            LbTrb2 = new System.Windows.Forms.Label();
+            LbTrb5 = new System.Windows.Forms.Label();
+            LbTrb3 = new System.Windows.Forms.Label();
+            LbTrb4 = new System.Windows.Forms.Label();
+            TrbRepetitions = new System.Windows.Forms.TrackBar();
+            GroupStartScreen.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)TrbWrongRight).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)TrbUnknown).BeginInit();
+            TabControlMain.SuspendLayout();
+            TabGeneral.SuspendLayout();
+            GroupUserInterface.SuspendLayout();
+            GroupVocabularyList.SuspendLayout();
+            GroupVhrPath.SuspendLayout();
+            GroupVhfPath.SuspendLayout();
+            GroupUpdate.SuspendLayout();
+            GroupSave.SuspendLayout();
+            TabPractice.SuspendLayout();
+            GroupEvaluation.SuspendLayout();
+            GroupPracticeUserInterface.SuspendLayout();
+            GroupNearlyCorrect.SuspendLayout();
+            TabPracticeSelect.SuspendLayout();
+            GroupSelectionMix.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox2).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox3).BeginInit();
+            GroupRepetitions.SuspendLayout();
+            PnlPracticeCount.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)TrbRepetitions).BeginInit();
+            SuspendLayout();
             // 
             // BtnOk
             // 
-            resources.ApplyResources(this.BtnOk, "BtnOk");
-            this.BtnOk.Name = "BtnOk";
-            this.BtnOk.UseVisualStyleBackColor = true;
-            this.BtnOk.Click += new System.EventHandler(this.BtnOk_Click);
+            resources.ApplyResources(BtnOk, "BtnOk");
+            BtnOk.Name = "BtnOk";
+            BtnOk.UseVisualStyleBackColor = true;
+            BtnOk.Click += BtnOk_Click;
             // 
             // BtnCancel
             // 
-            resources.ApplyResources(this.BtnCancel, "BtnCancel");
-            this.BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.BtnCancel.Name = "BtnCancel";
-            this.BtnCancel.UseVisualStyleBackColor = true;
+            resources.ApplyResources(BtnCancel, "BtnCancel");
+            BtnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            BtnCancel.Name = "BtnCancel";
+            BtnCancel.UseVisualStyleBackColor = true;
             // 
             // GroupStartScreen
             // 
-            this.GroupStartScreen.BackColor = System.Drawing.Color.Transparent;
-            this.GroupStartScreen.Controls.Add(this.BtnResetStartScreen);
-            this.GroupStartScreen.Controls.Add(this.RbEmptyStart);
-            this.GroupStartScreen.Controls.Add(this.RbRecentFile);
-            resources.ApplyResources(this.GroupStartScreen, "GroupStartScreen");
-            this.GroupStartScreen.Name = "GroupStartScreen";
-            this.GroupStartScreen.TabStop = false;
+            GroupStartScreen.BackColor = System.Drawing.Color.Transparent;
+            GroupStartScreen.Controls.Add(BtnResetStartScreen);
+            GroupStartScreen.Controls.Add(RbEmptyStart);
+            GroupStartScreen.Controls.Add(RbRecentFile);
+            resources.ApplyResources(GroupStartScreen, "GroupStartScreen");
+            GroupStartScreen.Name = "GroupStartScreen";
+            GroupStartScreen.TabStop = false;
             // 
             // BtnResetStartScreen
             // 
-            resources.ApplyResources(this.BtnResetStartScreen, "BtnResetStartScreen");
-            this.BtnResetStartScreen.Name = "BtnResetStartScreen";
-            this.BtnResetStartScreen.UseVisualStyleBackColor = true;
-            this.BtnResetStartScreen.Click += new System.EventHandler(this.BtnResetStartScreen_Click);
+            resources.ApplyResources(BtnResetStartScreen, "BtnResetStartScreen");
+            BtnResetStartScreen.Name = "BtnResetStartScreen";
+            BtnResetStartScreen.UseVisualStyleBackColor = true;
+            BtnResetStartScreen.Click += BtnResetStartScreen_Click;
             // 
             // RbEmptyStart
             // 
-            resources.ApplyResources(this.RbEmptyStart, "RbEmptyStart");
-            this.RbEmptyStart.Name = "RbEmptyStart";
-            this.RbEmptyStart.TabStop = true;
-            this.RbEmptyStart.UseVisualStyleBackColor = true;
+            resources.ApplyResources(RbEmptyStart, "RbEmptyStart");
+            RbEmptyStart.Name = "RbEmptyStart";
+            RbEmptyStart.TabStop = true;
+            RbEmptyStart.UseVisualStyleBackColor = true;
             // 
             // RbRecentFile
             // 
-            resources.ApplyResources(this.RbRecentFile, "RbRecentFile");
-            this.RbRecentFile.Checked = true;
-            this.RbRecentFile.Name = "RbRecentFile";
-            this.RbRecentFile.TabStop = true;
-            this.RbRecentFile.UseVisualStyleBackColor = true;
+            resources.ApplyResources(RbRecentFile, "RbRecentFile");
+            RbRecentFile.Checked = true;
+            RbRecentFile.Name = "RbRecentFile";
+            RbRecentFile.TabStop = true;
+            RbRecentFile.UseVisualStyleBackColor = true;
             // 
             // TrbWrongRight
             // 
-            this.TrbWrongRight.BackColor = System.Drawing.Color.White;
-            resources.ApplyResources(this.TrbWrongRight, "TrbWrongRight");
-            this.TrbWrongRight.Minimum = 1;
-            this.TrbWrongRight.Name = "TrbWrongRight";
-            this.TrbWrongRight.TickStyle = System.Windows.Forms.TickStyle.Both;
-            this.TrbWrongRight.Value = 5;
-            this.TrbWrongRight.ValueChanged += new System.EventHandler(this.TrbWrongRight_ValueChanged);
+            TrbWrongRight.BackColor = System.Drawing.Color.White;
+            resources.ApplyResources(TrbWrongRight, "TrbWrongRight");
+            TrbWrongRight.Minimum = 1;
+            TrbWrongRight.Name = "TrbWrongRight";
+            TrbWrongRight.TickStyle = System.Windows.Forms.TickStyle.Both;
+            TrbWrongRight.Value = 5;
+            TrbWrongRight.ValueChanged += TrbWrongRight_ValueChanged;
             // 
             // TrbUnknown
             // 
-            this.TrbUnknown.BackColor = System.Drawing.Color.White;
-            resources.ApplyResources(this.TrbUnknown, "TrbUnknown");
-            this.TrbUnknown.Maximum = 8;
-            this.TrbUnknown.Minimum = 1;
-            this.TrbUnknown.Name = "TrbUnknown";
-            this.TrbUnknown.TickStyle = System.Windows.Forms.TickStyle.Both;
-            this.TrbUnknown.Value = 5;
-            this.TrbUnknown.ValueChanged += new System.EventHandler(this.TrbUnknown_ValueChanged);
+            TrbUnknown.BackColor = System.Drawing.Color.White;
+            resources.ApplyResources(TrbUnknown, "TrbUnknown");
+            TrbUnknown.Maximum = 8;
+            TrbUnknown.Minimum = 1;
+            TrbUnknown.Name = "TrbUnknown";
+            TrbUnknown.TickStyle = System.Windows.Forms.TickStyle.Both;
+            TrbUnknown.Value = 5;
+            TrbUnknown.ValueChanged += TrbUnknown_ValueChanged;
             // 
             // TabControlMain
             // 
-            this.TabControlMain.Controls.Add(this.TabGeneral);
-            this.TabControlMain.Controls.Add(this.TabPractice);
-            this.TabControlMain.Controls.Add(this.TabPracticeSelect);
-            resources.ApplyResources(this.TabControlMain, "TabControlMain");
-            this.TabControlMain.Name = "TabControlMain";
-            this.TabControlMain.SelectedIndex = 0;
-            this.TabControlMain.Selected += new System.Windows.Forms.TabControlEventHandler(this.TabControlMain_Selected);
+            TabControlMain.Controls.Add(TabGeneral);
+            TabControlMain.Controls.Add(TabPractice);
+            TabControlMain.Controls.Add(TabPracticeSelect);
+            resources.ApplyResources(TabControlMain, "TabControlMain");
+            TabControlMain.Name = "TabControlMain";
+            TabControlMain.SelectedIndex = 0;
+            TabControlMain.Selected += TabControlMain_Selected;
             // 
             // TabGeneral
             // 
-            this.TabGeneral.BackColor = System.Drawing.Color.White;
-            this.TabGeneral.Controls.Add(this.GroupLanguage);
-            this.TabGeneral.Controls.Add(this.GroupVocabularyList);
-            this.TabGeneral.Controls.Add(this.GroupVhrPath);
-            this.TabGeneral.Controls.Add(this.GroupVhfPath);
-            this.TabGeneral.Controls.Add(this.GroupUpdate);
-            this.TabGeneral.Controls.Add(this.GroupSave);
-            this.TabGeneral.Controls.Add(this.GroupStartScreen);
-            resources.ApplyResources(this.TabGeneral, "TabGeneral");
-            this.TabGeneral.Name = "TabGeneral";
-            // 
-            // GroupLanguage
-            // 
-            this.GroupLanguage.Controls.Add(this.LbLanguage);
-            this.GroupLanguage.Controls.Add(this.CbLanguage);
-            resources.ApplyResources(this.GroupLanguage, "GroupLanguage");
-            this.GroupLanguage.Name = "GroupLanguage";
-            this.GroupLanguage.TabStop = false;
-            // 
-            // LbLanguage
-            // 
-            resources.ApplyResources(this.LbLanguage, "LbLanguage");
-            this.LbLanguage.Name = "LbLanguage";
-            // 
-            // CbLanguage
-            // 
-            this.CbLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CbLanguage.FormattingEnabled = true;
-            this.CbLanguage.Items.AddRange(new object[] {
-            resources.GetString("CbLanguage.Items"),
-            resources.GetString("CbLanguage.Items1"),
-            resources.GetString("CbLanguage.Items2"),
-            resources.GetString("CbLanguage.Items3")});
-            resources.ApplyResources(this.CbLanguage, "CbLanguage");
-            this.CbLanguage.Name = "CbLanguage";
-            // 
-            // GroupVocabularyList
-            // 
-            this.GroupVocabularyList.BackColor = System.Drawing.Color.Transparent;
-            this.GroupVocabularyList.Controls.Add(this.CbColumnResize);
-            resources.ApplyResources(this.GroupVocabularyList, "GroupVocabularyList");
-            this.GroupVocabularyList.Name = "GroupVocabularyList";
-            this.GroupVocabularyList.TabStop = false;
-            // 
-            // CbColumnResize
-            // 
-            resources.ApplyResources(this.CbColumnResize, "CbColumnResize");
-            this.CbColumnResize.Name = "CbColumnResize";
-            this.CbColumnResize.UseVisualStyleBackColor = true;
-            // 
-            // GroupVhrPath
-            // 
-            this.GroupVhrPath.Controls.Add(this.BtnVhrPath);
-            this.GroupVhrPath.Controls.Add(this.TbVhrPath);
-            resources.ApplyResources(this.GroupVhrPath, "GroupVhrPath");
-            this.GroupVhrPath.Name = "GroupVhrPath";
-            this.GroupVhrPath.TabStop = false;
-            // 
-            // BtnVhrPath
-            // 
-            resources.ApplyResources(this.BtnVhrPath, "BtnVhrPath");
-            this.BtnVhrPath.Name = "BtnVhrPath";
-            this.BtnVhrPath.UseVisualStyleBackColor = true;
-            this.BtnVhrPath.Click += new System.EventHandler(this.BtnVhrPath_Click);
-            // 
-            // TbVhrPath
-            // 
-            resources.ApplyResources(this.TbVhrPath, "TbVhrPath");
-            this.TbVhrPath.Name = "TbVhrPath";
-            this.TbVhrPath.ReadOnly = true;
-            // 
-            // GroupVhfPath
-            // 
-            this.GroupVhfPath.Controls.Add(this.BtnVhfPath);
-            this.GroupVhfPath.Controls.Add(this.TbVhfPath);
-            resources.ApplyResources(this.GroupVhfPath, "GroupVhfPath");
-            this.GroupVhfPath.Name = "GroupVhfPath";
-            this.GroupVhfPath.TabStop = false;
-            // 
-            // BtnVhfPath
-            // 
-            resources.ApplyResources(this.BtnVhfPath, "BtnVhfPath");
-            this.BtnVhfPath.Name = "BtnVhfPath";
-            this.BtnVhfPath.UseVisualStyleBackColor = true;
-            this.BtnVhfPath.Click += new System.EventHandler(this.BtnVhfPath_Click);
-            // 
-            // TbVhfPath
-            // 
-            resources.ApplyResources(this.TbVhfPath, "TbVhfPath");
-            this.TbVhfPath.Name = "TbVhfPath";
-            this.TbVhfPath.ReadOnly = true;
-            // 
-            // GroupUpdate
-            // 
-            this.GroupUpdate.BackColor = System.Drawing.Color.Transparent;
-            this.GroupUpdate.Controls.Add(this.CbDisableInternetServices);
-            resources.ApplyResources(this.GroupUpdate, "GroupUpdate");
-            this.GroupUpdate.Name = "GroupUpdate";
-            this.GroupUpdate.TabStop = false;
-            // 
-            // CbDisableInternetServices
-            // 
-            resources.ApplyResources(this.CbDisableInternetServices, "CbDisableInternetServices");
-            this.CbDisableInternetServices.Name = "CbDisableInternetServices";
-            this.CbDisableInternetServices.UseVisualStyleBackColor = true;
-            // 
-            // GroupSave
-            // 
-            this.GroupSave.BackColor = System.Drawing.Color.Transparent;
-            this.GroupSave.Controls.Add(this.CbAutoSave);
-            resources.ApplyResources(this.GroupSave, "GroupSave");
-            this.GroupSave.Name = "GroupSave";
-            this.GroupSave.TabStop = false;
-            // 
-            // CbAutoSave
-            // 
-            resources.ApplyResources(this.CbAutoSave, "CbAutoSave");
-            this.CbAutoSave.Name = "CbAutoSave";
-            this.CbAutoSave.UseVisualStyleBackColor = true;
-            // 
-            // TabPractice
-            // 
-            this.TabPractice.BackColor = System.Drawing.Color.White;
-            this.TabPractice.Controls.Add(this.GroupEvaluation);
-            this.TabPractice.Controls.Add(this.GroupUserInterface);
-            this.TabPractice.Controls.Add(this.GroupNearlyCorrect);
-            resources.ApplyResources(this.TabPractice, "TabPractice");
-            this.TabPractice.Name = "TabPractice";
-            // 
-            // GroupEvaluation
-            // 
-            this.GroupEvaluation.Controls.Add(this.CbOptionalExpressions);
-            this.GroupEvaluation.Controls.Add(this.CbManualCheck);
-            this.GroupEvaluation.Controls.Add(this.CbShowPracticeResult);
-            resources.ApplyResources(this.GroupEvaluation, "GroupEvaluation");
-            this.GroupEvaluation.Name = "GroupEvaluation";
-            this.GroupEvaluation.TabStop = false;
-            // 
-            // CbOptionalExpressions
-            // 
-            resources.ApplyResources(this.CbOptionalExpressions, "CbOptionalExpressions");
-            this.CbOptionalExpressions.Checked = true;
-            this.CbOptionalExpressions.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbOptionalExpressions.Name = "CbOptionalExpressions";
-            this.CbOptionalExpressions.UseVisualStyleBackColor = true;
-            // 
-            // CbManualCheck
-            // 
-            resources.ApplyResources(this.CbManualCheck, "CbManualCheck");
-            this.CbManualCheck.Name = "CbManualCheck";
-            this.CbManualCheck.UseVisualStyleBackColor = true;
-            // 
-            // CbShowPracticeResult
-            // 
-            resources.ApplyResources(this.CbShowPracticeResult, "CbShowPracticeResult");
-            this.CbShowPracticeResult.Checked = true;
-            this.CbShowPracticeResult.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbShowPracticeResult.Name = "CbShowPracticeResult";
-            this.CbShowPracticeResult.UseVisualStyleBackColor = true;
+            TabGeneral.BackColor = System.Drawing.Color.White;
+            TabGeneral.Controls.Add(GroupUserInterface);
+            TabGeneral.Controls.Add(GroupVocabularyList);
+            TabGeneral.Controls.Add(GroupVhrPath);
+            TabGeneral.Controls.Add(GroupVhfPath);
+            TabGeneral.Controls.Add(GroupUpdate);
+            TabGeneral.Controls.Add(GroupSave);
+            TabGeneral.Controls.Add(GroupStartScreen);
+            resources.ApplyResources(TabGeneral, "TabGeneral");
+            TabGeneral.Name = "TabGeneral";
             // 
             // GroupUserInterface
             // 
-            this.GroupUserInterface.Controls.Add(this.CbAcousticFeedback);
-            this.GroupUserInterface.Controls.Add(this.CbSingleContinueButton);
-            resources.ApplyResources(this.GroupUserInterface, "GroupUserInterface");
-            this.GroupUserInterface.Name = "GroupUserInterface";
-            this.GroupUserInterface.TabStop = false;
+            GroupUserInterface.Controls.Add(CbColorTheme);
+            GroupUserInterface.Controls.Add(LbColorTheme);
+            GroupUserInterface.Controls.Add(LbLanguage);
+            GroupUserInterface.Controls.Add(CbLanguage);
+            resources.ApplyResources(GroupUserInterface, "GroupUserInterface");
+            GroupUserInterface.Name = "GroupUserInterface";
+            GroupUserInterface.TabStop = false;
+            // 
+            // CbColorTheme
+            // 
+            CbColorTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            CbColorTheme.FormattingEnabled = true;
+            CbColorTheme.Items.AddRange(new object[] { resources.GetString("CbColorTheme.Items"), resources.GetString("CbColorTheme.Items1"), resources.GetString("CbColorTheme.Items2") });
+            resources.ApplyResources(CbColorTheme, "CbColorTheme");
+            CbColorTheme.Name = "CbColorTheme";
+            // 
+            // LbColorTheme
+            // 
+            resources.ApplyResources(LbColorTheme, "LbColorTheme");
+            LbColorTheme.Name = "LbColorTheme";
+            // 
+            // LbLanguage
+            // 
+            resources.ApplyResources(LbLanguage, "LbLanguage");
+            LbLanguage.Name = "LbLanguage";
+            // 
+            // CbLanguage
+            // 
+            CbLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            CbLanguage.FormattingEnabled = true;
+            CbLanguage.Items.AddRange(new object[] { resources.GetString("CbLanguage.Items"), resources.GetString("CbLanguage.Items1"), resources.GetString("CbLanguage.Items2"), resources.GetString("CbLanguage.Items3") });
+            resources.ApplyResources(CbLanguage, "CbLanguage");
+            CbLanguage.Name = "CbLanguage";
+            // 
+            // GroupVocabularyList
+            // 
+            GroupVocabularyList.BackColor = System.Drawing.Color.Transparent;
+            GroupVocabularyList.Controls.Add(CbColumnResize);
+            resources.ApplyResources(GroupVocabularyList, "GroupVocabularyList");
+            GroupVocabularyList.Name = "GroupVocabularyList";
+            GroupVocabularyList.TabStop = false;
+            // 
+            // CbColumnResize
+            // 
+            resources.ApplyResources(CbColumnResize, "CbColumnResize");
+            CbColumnResize.Name = "CbColumnResize";
+            CbColumnResize.UseVisualStyleBackColor = true;
+            // 
+            // GroupVhrPath
+            // 
+            GroupVhrPath.Controls.Add(BtnVhrPath);
+            GroupVhrPath.Controls.Add(TbVhrPath);
+            resources.ApplyResources(GroupVhrPath, "GroupVhrPath");
+            GroupVhrPath.Name = "GroupVhrPath";
+            GroupVhrPath.TabStop = false;
+            // 
+            // BtnVhrPath
+            // 
+            resources.ApplyResources(BtnVhrPath, "BtnVhrPath");
+            BtnVhrPath.Name = "BtnVhrPath";
+            BtnVhrPath.UseVisualStyleBackColor = true;
+            BtnVhrPath.Click += BtnVhrPath_Click;
+            // 
+            // TbVhrPath
+            // 
+            resources.ApplyResources(TbVhrPath, "TbVhrPath");
+            TbVhrPath.Name = "TbVhrPath";
+            TbVhrPath.ReadOnly = true;
+            // 
+            // GroupVhfPath
+            // 
+            GroupVhfPath.Controls.Add(BtnVhfPath);
+            GroupVhfPath.Controls.Add(TbVhfPath);
+            resources.ApplyResources(GroupVhfPath, "GroupVhfPath");
+            GroupVhfPath.Name = "GroupVhfPath";
+            GroupVhfPath.TabStop = false;
+            // 
+            // BtnVhfPath
+            // 
+            resources.ApplyResources(BtnVhfPath, "BtnVhfPath");
+            BtnVhfPath.Name = "BtnVhfPath";
+            BtnVhfPath.UseVisualStyleBackColor = true;
+            BtnVhfPath.Click += BtnVhfPath_Click;
+            // 
+            // TbVhfPath
+            // 
+            resources.ApplyResources(TbVhfPath, "TbVhfPath");
+            TbVhfPath.Name = "TbVhfPath";
+            TbVhfPath.ReadOnly = true;
+            // 
+            // GroupUpdate
+            // 
+            GroupUpdate.BackColor = System.Drawing.Color.Transparent;
+            GroupUpdate.Controls.Add(CbDisableInternetServices);
+            resources.ApplyResources(GroupUpdate, "GroupUpdate");
+            GroupUpdate.Name = "GroupUpdate";
+            GroupUpdate.TabStop = false;
+            // 
+            // CbDisableInternetServices
+            // 
+            resources.ApplyResources(CbDisableInternetServices, "CbDisableInternetServices");
+            CbDisableInternetServices.Name = "CbDisableInternetServices";
+            CbDisableInternetServices.UseVisualStyleBackColor = true;
+            // 
+            // GroupSave
+            // 
+            GroupSave.BackColor = System.Drawing.Color.Transparent;
+            GroupSave.Controls.Add(CbAutoSave);
+            resources.ApplyResources(GroupSave, "GroupSave");
+            GroupSave.Name = "GroupSave";
+            GroupSave.TabStop = false;
+            // 
+            // CbAutoSave
+            // 
+            resources.ApplyResources(CbAutoSave, "CbAutoSave");
+            CbAutoSave.Name = "CbAutoSave";
+            CbAutoSave.UseVisualStyleBackColor = true;
+            // 
+            // TabPractice
+            // 
+            TabPractice.BackColor = System.Drawing.Color.White;
+            TabPractice.Controls.Add(GroupEvaluation);
+            TabPractice.Controls.Add(GroupPracticeUserInterface);
+            TabPractice.Controls.Add(GroupNearlyCorrect);
+            resources.ApplyResources(TabPractice, "TabPractice");
+            TabPractice.Name = "TabPractice";
+            // 
+            // GroupEvaluation
+            // 
+            GroupEvaluation.Controls.Add(CbOptionalExpressions);
+            GroupEvaluation.Controls.Add(CbManualCheck);
+            GroupEvaluation.Controls.Add(CbShowPracticeResult);
+            resources.ApplyResources(GroupEvaluation, "GroupEvaluation");
+            GroupEvaluation.Name = "GroupEvaluation";
+            GroupEvaluation.TabStop = false;
+            // 
+            // CbOptionalExpressions
+            // 
+            resources.ApplyResources(CbOptionalExpressions, "CbOptionalExpressions");
+            CbOptionalExpressions.Checked = true;
+            CbOptionalExpressions.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbOptionalExpressions.Name = "CbOptionalExpressions";
+            CbOptionalExpressions.UseVisualStyleBackColor = true;
+            // 
+            // CbManualCheck
+            // 
+            resources.ApplyResources(CbManualCheck, "CbManualCheck");
+            CbManualCheck.Name = "CbManualCheck";
+            CbManualCheck.UseVisualStyleBackColor = true;
+            // 
+            // CbShowPracticeResult
+            // 
+            resources.ApplyResources(CbShowPracticeResult, "CbShowPracticeResult");
+            CbShowPracticeResult.Checked = true;
+            CbShowPracticeResult.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbShowPracticeResult.Name = "CbShowPracticeResult";
+            CbShowPracticeResult.UseVisualStyleBackColor = true;
+            // 
+            // GroupPracticeUserInterface
+            // 
+            GroupPracticeUserInterface.Controls.Add(CbAcousticFeedback);
+            GroupPracticeUserInterface.Controls.Add(CbSingleContinueButton);
+            resources.ApplyResources(GroupPracticeUserInterface, "GroupPracticeUserInterface");
+            GroupPracticeUserInterface.Name = "GroupPracticeUserInterface";
+            GroupPracticeUserInterface.TabStop = false;
             // 
             // CbAcousticFeedback
             // 
-            resources.ApplyResources(this.CbAcousticFeedback, "CbAcousticFeedback");
-            this.CbAcousticFeedback.Checked = true;
-            this.CbAcousticFeedback.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbAcousticFeedback.Name = "CbAcousticFeedback";
-            this.CbAcousticFeedback.UseVisualStyleBackColor = true;
+            resources.ApplyResources(CbAcousticFeedback, "CbAcousticFeedback");
+            CbAcousticFeedback.Checked = true;
+            CbAcousticFeedback.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbAcousticFeedback.Name = "CbAcousticFeedback";
+            CbAcousticFeedback.UseVisualStyleBackColor = true;
             // 
             // CbSingleContinueButton
             // 
-            resources.ApplyResources(this.CbSingleContinueButton, "CbSingleContinueButton");
-            this.CbSingleContinueButton.BackColor = System.Drawing.Color.Transparent;
-            this.CbSingleContinueButton.Name = "CbSingleContinueButton";
-            this.CbSingleContinueButton.UseVisualStyleBackColor = false;
+            resources.ApplyResources(CbSingleContinueButton, "CbSingleContinueButton");
+            CbSingleContinueButton.BackColor = System.Drawing.Color.Transparent;
+            CbSingleContinueButton.Name = "CbSingleContinueButton";
+            CbSingleContinueButton.UseVisualStyleBackColor = false;
             // 
             // GroupNearlyCorrect
             // 
-            this.GroupNearlyCorrect.Controls.Add(this.CbTolerateWhiteSpace);
-            this.GroupNearlyCorrect.Controls.Add(this.CbTolerateNoSynonym);
-            this.GroupNearlyCorrect.Controls.Add(this.CbTolerateArticle);
-            this.GroupNearlyCorrect.Controls.Add(this.CbToleratePunctuationMark);
-            this.GroupNearlyCorrect.Controls.Add(this.CbTolerateSpecialChar);
-            resources.ApplyResources(this.GroupNearlyCorrect, "GroupNearlyCorrect");
-            this.GroupNearlyCorrect.Name = "GroupNearlyCorrect";
-            this.GroupNearlyCorrect.TabStop = false;
+            GroupNearlyCorrect.Controls.Add(CbTolerateWhiteSpace);
+            GroupNearlyCorrect.Controls.Add(CbTolerateNoSynonym);
+            GroupNearlyCorrect.Controls.Add(CbTolerateArticle);
+            GroupNearlyCorrect.Controls.Add(CbToleratePunctuationMark);
+            GroupNearlyCorrect.Controls.Add(CbTolerateSpecialChar);
+            resources.ApplyResources(GroupNearlyCorrect, "GroupNearlyCorrect");
+            GroupNearlyCorrect.Name = "GroupNearlyCorrect";
+            GroupNearlyCorrect.TabStop = false;
             // 
             // CbTolerateWhiteSpace
             // 
-            resources.ApplyResources(this.CbTolerateWhiteSpace, "CbTolerateWhiteSpace");
-            this.CbTolerateWhiteSpace.Checked = true;
-            this.CbTolerateWhiteSpace.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbTolerateWhiteSpace.Name = "CbTolerateWhiteSpace";
-            this.CbTolerateWhiteSpace.UseVisualStyleBackColor = true;
+            resources.ApplyResources(CbTolerateWhiteSpace, "CbTolerateWhiteSpace");
+            CbTolerateWhiteSpace.Checked = true;
+            CbTolerateWhiteSpace.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbTolerateWhiteSpace.Name = "CbTolerateWhiteSpace";
+            CbTolerateWhiteSpace.UseVisualStyleBackColor = true;
             // 
             // CbTolerateNoSynonym
             // 
-            resources.ApplyResources(this.CbTolerateNoSynonym, "CbTolerateNoSynonym");
-            this.CbTolerateNoSynonym.Checked = true;
-            this.CbTolerateNoSynonym.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbTolerateNoSynonym.Name = "CbTolerateNoSynonym";
-            this.CbTolerateNoSynonym.UseVisualStyleBackColor = true;
+            resources.ApplyResources(CbTolerateNoSynonym, "CbTolerateNoSynonym");
+            CbTolerateNoSynonym.Checked = true;
+            CbTolerateNoSynonym.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbTolerateNoSynonym.Name = "CbTolerateNoSynonym";
+            CbTolerateNoSynonym.UseVisualStyleBackColor = true;
             // 
             // CbTolerateArticle
             // 
-            resources.ApplyResources(this.CbTolerateArticle, "CbTolerateArticle");
-            this.CbTolerateArticle.Checked = true;
-            this.CbTolerateArticle.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbTolerateArticle.Name = "CbTolerateArticle";
-            this.CbTolerateArticle.UseVisualStyleBackColor = true;
+            resources.ApplyResources(CbTolerateArticle, "CbTolerateArticle");
+            CbTolerateArticle.Checked = true;
+            CbTolerateArticle.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbTolerateArticle.Name = "CbTolerateArticle";
+            CbTolerateArticle.UseVisualStyleBackColor = true;
             // 
             // CbToleratePunctuationMark
             // 
-            resources.ApplyResources(this.CbToleratePunctuationMark, "CbToleratePunctuationMark");
-            this.CbToleratePunctuationMark.Checked = true;
-            this.CbToleratePunctuationMark.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbToleratePunctuationMark.Name = "CbToleratePunctuationMark";
-            this.CbToleratePunctuationMark.UseVisualStyleBackColor = true;
+            resources.ApplyResources(CbToleratePunctuationMark, "CbToleratePunctuationMark");
+            CbToleratePunctuationMark.Checked = true;
+            CbToleratePunctuationMark.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbToleratePunctuationMark.Name = "CbToleratePunctuationMark";
+            CbToleratePunctuationMark.UseVisualStyleBackColor = true;
             // 
             // CbTolerateSpecialChar
             // 
-            resources.ApplyResources(this.CbTolerateSpecialChar, "CbTolerateSpecialChar");
-            this.CbTolerateSpecialChar.Checked = true;
-            this.CbTolerateSpecialChar.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CbTolerateSpecialChar.Name = "CbTolerateSpecialChar";
-            this.CbTolerateSpecialChar.UseVisualStyleBackColor = true;
+            resources.ApplyResources(CbTolerateSpecialChar, "CbTolerateSpecialChar");
+            CbTolerateSpecialChar.Checked = true;
+            CbTolerateSpecialChar.CheckState = System.Windows.Forms.CheckState.Checked;
+            CbTolerateSpecialChar.Name = "CbTolerateSpecialChar";
+            CbTolerateSpecialChar.UseVisualStyleBackColor = true;
             // 
             // TabPracticeSelect
             // 
-            this.TabPracticeSelect.BackColor = System.Drawing.Color.White;
-            this.TabPracticeSelect.Controls.Add(this.BtnResetPracticeSelect);
-            this.TabPracticeSelect.Controls.Add(this.GroupSelectionMix);
-            this.TabPracticeSelect.Controls.Add(this.GroupRepetitions);
-            resources.ApplyResources(this.TabPracticeSelect, "TabPracticeSelect");
-            this.TabPracticeSelect.Name = "TabPracticeSelect";
+            TabPracticeSelect.BackColor = System.Drawing.Color.White;
+            TabPracticeSelect.Controls.Add(BtnResetPracticeSelect);
+            TabPracticeSelect.Controls.Add(GroupSelectionMix);
+            TabPracticeSelect.Controls.Add(GroupRepetitions);
+            resources.ApplyResources(TabPracticeSelect, "TabPracticeSelect");
+            TabPracticeSelect.Name = "TabPracticeSelect";
             // 
             // BtnResetPracticeSelect
             // 
-            resources.ApplyResources(this.BtnResetPracticeSelect, "BtnResetPracticeSelect");
-            this.BtnResetPracticeSelect.Name = "BtnResetPracticeSelect";
-            this.BtnResetPracticeSelect.UseVisualStyleBackColor = true;
-            this.BtnResetPracticeSelect.Click += new System.EventHandler(this.BtnResetPractice_Click);
+            resources.ApplyResources(BtnResetPracticeSelect, "BtnResetPracticeSelect");
+            BtnResetPracticeSelect.Name = "BtnResetPracticeSelect";
+            BtnResetPracticeSelect.UseVisualStyleBackColor = true;
+            BtnResetPracticeSelect.Click += BtnResetPractice_Click;
             // 
             // GroupSelectionMix
             // 
-            this.GroupSelectionMix.Controls.Add(this.LbWronglyPracticed);
-            this.GroupSelectionMix.Controls.Add(this.LbCorrectlyPracticed);
-            this.GroupSelectionMix.Controls.Add(this.LbUnpracticed);
-            this.GroupSelectionMix.Controls.Add(this.LbPercentageUnpracticed);
-            this.GroupSelectionMix.Controls.Add(this.pictureBox2);
-            this.GroupSelectionMix.Controls.Add(this.pictureBox1);
-            this.GroupSelectionMix.Controls.Add(this.pictureBox3);
-            this.GroupSelectionMix.Controls.Add(this.LbPercentageWrongCorrect);
-            this.GroupSelectionMix.Controls.Add(this.TrbUnknown);
-            this.GroupSelectionMix.Controls.Add(this.TrbWrongRight);
-            resources.ApplyResources(this.GroupSelectionMix, "GroupSelectionMix");
-            this.GroupSelectionMix.Name = "GroupSelectionMix";
-            this.GroupSelectionMix.TabStop = false;
+            GroupSelectionMix.Controls.Add(LbWronglyPracticed);
+            GroupSelectionMix.Controls.Add(LbCorrectlyPracticed);
+            GroupSelectionMix.Controls.Add(LbUnpracticed);
+            GroupSelectionMix.Controls.Add(LbPercentageUnpracticed);
+            GroupSelectionMix.Controls.Add(pictureBox2);
+            GroupSelectionMix.Controls.Add(pictureBox1);
+            GroupSelectionMix.Controls.Add(pictureBox3);
+            GroupSelectionMix.Controls.Add(LbPercentageWrongCorrect);
+            GroupSelectionMix.Controls.Add(TrbUnknown);
+            GroupSelectionMix.Controls.Add(TrbWrongRight);
+            resources.ApplyResources(GroupSelectionMix, "GroupSelectionMix");
+            GroupSelectionMix.Name = "GroupSelectionMix";
+            GroupSelectionMix.TabStop = false;
             // 
             // LbWronglyPracticed
             // 
-            resources.ApplyResources(this.LbWronglyPracticed, "LbWronglyPracticed");
-            this.LbWronglyPracticed.Name = "LbWronglyPracticed";
+            resources.ApplyResources(LbWronglyPracticed, "LbWronglyPracticed");
+            LbWronglyPracticed.Name = "LbWronglyPracticed";
             // 
             // LbCorrectlyPracticed
             // 
-            resources.ApplyResources(this.LbCorrectlyPracticed, "LbCorrectlyPracticed");
-            this.LbCorrectlyPracticed.Name = "LbCorrectlyPracticed";
+            resources.ApplyResources(LbCorrectlyPracticed, "LbCorrectlyPracticed");
+            LbCorrectlyPracticed.Name = "LbCorrectlyPracticed";
             // 
             // LbUnpracticed
             // 
-            resources.ApplyResources(this.LbUnpracticed, "LbUnpracticed");
-            this.LbUnpracticed.Name = "LbUnpracticed";
+            resources.ApplyResources(LbUnpracticed, "LbUnpracticed");
+            LbUnpracticed.Name = "LbUnpracticed";
             // 
             // LbPercentageUnpracticed
             // 
-            resources.ApplyResources(this.LbPercentageUnpracticed, "LbPercentageUnpracticed");
-            this.LbPercentageUnpracticed.Name = "LbPercentageUnpracticed";
+            resources.ApplyResources(LbPercentageUnpracticed, "LbPercentageUnpracticed");
+            LbPercentageUnpracticed.Name = "LbPercentageUnpracticed";
             // 
             // pictureBox2
             // 
-            this.pictureBox2.Image = global::Vocup.Properties.Icons.WronglyPracticed;
-            resources.ApplyResources(this.pictureBox2, "pictureBox2");
-            this.pictureBox2.Name = "pictureBox2";
-            this.pictureBox2.TabStop = false;
+            pictureBox2.Image = Properties.Icons.WronglyPracticed;
+            resources.ApplyResources(pictureBox2, "pictureBox2");
+            pictureBox2.Name = "pictureBox2";
+            pictureBox2.TabStop = false;
             // 
             // pictureBox1
             // 
-            this.pictureBox1.Image = global::Vocup.Properties.Icons.Unpracticed;
-            resources.ApplyResources(this.pictureBox1, "pictureBox1");
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.TabStop = false;
+            pictureBox1.Image = Properties.Icons.Unpracticed;
+            resources.ApplyResources(pictureBox1, "pictureBox1");
+            pictureBox1.Name = "pictureBox1";
+            pictureBox1.TabStop = false;
             // 
             // pictureBox3
             // 
-            this.pictureBox3.Image = global::Vocup.Properties.Icons.CorrectlyPracticed;
-            resources.ApplyResources(this.pictureBox3, "pictureBox3");
-            this.pictureBox3.Name = "pictureBox3";
-            this.pictureBox3.TabStop = false;
+            pictureBox3.Image = Properties.Icons.CorrectlyPracticed;
+            resources.ApplyResources(pictureBox3, "pictureBox3");
+            pictureBox3.Name = "pictureBox3";
+            pictureBox3.TabStop = false;
             // 
             // LbPercentageWrongCorrect
             // 
-            resources.ApplyResources(this.LbPercentageWrongCorrect, "LbPercentageWrongCorrect");
-            this.LbPercentageWrongCorrect.Name = "LbPercentageWrongCorrect";
+            resources.ApplyResources(LbPercentageWrongCorrect, "LbPercentageWrongCorrect");
+            LbPercentageWrongCorrect.Name = "LbPercentageWrongCorrect";
             // 
             // GroupRepetitions
             // 
-            this.GroupRepetitions.Controls.Add(this.LbPracticeCount);
-            this.GroupRepetitions.Controls.Add(this.PnlPracticeCount);
-            resources.ApplyResources(this.GroupRepetitions, "GroupRepetitions");
-            this.GroupRepetitions.Name = "GroupRepetitions";
-            this.GroupRepetitions.TabStop = false;
+            GroupRepetitions.Controls.Add(LbPracticeCount);
+            GroupRepetitions.Controls.Add(PnlPracticeCount);
+            resources.ApplyResources(GroupRepetitions, "GroupRepetitions");
+            GroupRepetitions.Name = "GroupRepetitions";
+            GroupRepetitions.TabStop = false;
             // 
             // LbPracticeCount
             // 
-            this.LbPracticeCount.AutoEllipsis = true;
-            resources.ApplyResources(this.LbPracticeCount, "LbPracticeCount");
-            this.LbPracticeCount.Name = "LbPracticeCount";
+            LbPracticeCount.AutoEllipsis = true;
+            resources.ApplyResources(LbPracticeCount, "LbPracticeCount");
+            LbPracticeCount.Name = "LbPracticeCount";
             // 
             // PnlPracticeCount
             // 
-            this.PnlPracticeCount.Controls.Add(this.LbTrb6);
-            this.PnlPracticeCount.Controls.Add(this.LbTrb2);
-            this.PnlPracticeCount.Controls.Add(this.LbTrb5);
-            this.PnlPracticeCount.Controls.Add(this.LbTrb3);
-            this.PnlPracticeCount.Controls.Add(this.LbTrb4);
-            this.PnlPracticeCount.Controls.Add(this.TrbRepetitions);
-            resources.ApplyResources(this.PnlPracticeCount, "PnlPracticeCount");
-            this.PnlPracticeCount.Name = "PnlPracticeCount";
+            PnlPracticeCount.Controls.Add(LbTrb6);
+            PnlPracticeCount.Controls.Add(LbTrb2);
+            PnlPracticeCount.Controls.Add(LbTrb5);
+            PnlPracticeCount.Controls.Add(LbTrb3);
+            PnlPracticeCount.Controls.Add(LbTrb4);
+            PnlPracticeCount.Controls.Add(TrbRepetitions);
+            resources.ApplyResources(PnlPracticeCount, "PnlPracticeCount");
+            PnlPracticeCount.Name = "PnlPracticeCount";
             // 
             // LbTrb6
             // 
-            resources.ApplyResources(this.LbTrb6, "LbTrb6");
-            this.LbTrb6.Name = "LbTrb6";
+            resources.ApplyResources(LbTrb6, "LbTrb6");
+            LbTrb6.Name = "LbTrb6";
             // 
             // LbTrb2
             // 
-            resources.ApplyResources(this.LbTrb2, "LbTrb2");
-            this.LbTrb2.Name = "LbTrb2";
+            resources.ApplyResources(LbTrb2, "LbTrb2");
+            LbTrb2.Name = "LbTrb2";
             // 
             // LbTrb5
             // 
-            resources.ApplyResources(this.LbTrb5, "LbTrb5");
-            this.LbTrb5.Name = "LbTrb5";
+            resources.ApplyResources(LbTrb5, "LbTrb5");
+            LbTrb5.Name = "LbTrb5";
             // 
             // LbTrb3
             // 
-            resources.ApplyResources(this.LbTrb3, "LbTrb3");
-            this.LbTrb3.Name = "LbTrb3";
+            resources.ApplyResources(LbTrb3, "LbTrb3");
+            LbTrb3.Name = "LbTrb3";
             // 
             // LbTrb4
             // 
-            resources.ApplyResources(this.LbTrb4, "LbTrb4");
-            this.LbTrb4.Name = "LbTrb4";
+            resources.ApplyResources(LbTrb4, "LbTrb4");
+            LbTrb4.Name = "LbTrb4";
             // 
             // TrbRepetitions
             // 
-            this.TrbRepetitions.BackColor = System.Drawing.Color.White;
-            this.TrbRepetitions.LargeChange = 1;
-            resources.ApplyResources(this.TrbRepetitions, "TrbRepetitions");
-            this.TrbRepetitions.Maximum = 6;
-            this.TrbRepetitions.Minimum = 2;
-            this.TrbRepetitions.Name = "TrbRepetitions";
-            this.TrbRepetitions.Value = 3;
+            TrbRepetitions.BackColor = System.Drawing.Color.White;
+            TrbRepetitions.LargeChange = 1;
+            resources.ApplyResources(TrbRepetitions, "TrbRepetitions");
+            TrbRepetitions.Maximum = 6;
+            TrbRepetitions.Minimum = 2;
+            TrbRepetitions.Name = "TrbRepetitions";
+            TrbRepetitions.Value = 3;
             // 
             // SettingsDialog
             // 
-            this.AcceptButton = this.BtnOk;
+            AcceptButton = BtnOk;
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.BtnCancel;
-            this.Controls.Add(this.TabControlMain);
-            this.Controls.Add(this.BtnCancel);
-            this.Controls.Add(this.BtnOk);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "SettingsDialog";
-            this.ShowInTaskbar = false;
-            this.Load += new System.EventHandler(this.SettingsDialog_Load);
-            this.GroupStartScreen.ResumeLayout(false);
-            this.GroupStartScreen.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.TrbWrongRight)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TrbUnknown)).EndInit();
-            this.TabControlMain.ResumeLayout(false);
-            this.TabGeneral.ResumeLayout(false);
-            this.GroupLanguage.ResumeLayout(false);
-            this.GroupLanguage.PerformLayout();
-            this.GroupVocabularyList.ResumeLayout(false);
-            this.GroupVocabularyList.PerformLayout();
-            this.GroupVhrPath.ResumeLayout(false);
-            this.GroupVhrPath.PerformLayout();
-            this.GroupVhfPath.ResumeLayout(false);
-            this.GroupVhfPath.PerformLayout();
-            this.GroupUpdate.ResumeLayout(false);
-            this.GroupUpdate.PerformLayout();
-            this.GroupSave.ResumeLayout(false);
-            this.GroupSave.PerformLayout();
-            this.TabPractice.ResumeLayout(false);
-            this.GroupEvaluation.ResumeLayout(false);
-            this.GroupEvaluation.PerformLayout();
-            this.GroupUserInterface.ResumeLayout(false);
-            this.GroupUserInterface.PerformLayout();
-            this.GroupNearlyCorrect.ResumeLayout(false);
-            this.GroupNearlyCorrect.PerformLayout();
-            this.TabPracticeSelect.ResumeLayout(false);
-            this.GroupSelectionMix.ResumeLayout(false);
-            this.GroupSelectionMix.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
-            this.GroupRepetitions.ResumeLayout(false);
-            this.GroupRepetitions.PerformLayout();
-            this.PnlPracticeCount.ResumeLayout(false);
-            this.PnlPracticeCount.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.TrbRepetitions)).EndInit();
-            this.ResumeLayout(false);
-
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = BtnCancel;
+            Controls.Add(TabControlMain);
+            Controls.Add(BtnCancel);
+            Controls.Add(BtnOk);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "SettingsDialog";
+            ShowInTaskbar = false;
+            Load += SettingsDialog_Load;
+            GroupStartScreen.ResumeLayout(false);
+            GroupStartScreen.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)TrbWrongRight).EndInit();
+            ((System.ComponentModel.ISupportInitialize)TrbUnknown).EndInit();
+            TabControlMain.ResumeLayout(false);
+            TabGeneral.ResumeLayout(false);
+            GroupUserInterface.ResumeLayout(false);
+            GroupUserInterface.PerformLayout();
+            GroupVocabularyList.ResumeLayout(false);
+            GroupVocabularyList.PerformLayout();
+            GroupVhrPath.ResumeLayout(false);
+            GroupVhrPath.PerformLayout();
+            GroupVhfPath.ResumeLayout(false);
+            GroupVhfPath.PerformLayout();
+            GroupUpdate.ResumeLayout(false);
+            GroupUpdate.PerformLayout();
+            GroupSave.ResumeLayout(false);
+            GroupSave.PerformLayout();
+            TabPractice.ResumeLayout(false);
+            GroupEvaluation.ResumeLayout(false);
+            GroupEvaluation.PerformLayout();
+            GroupPracticeUserInterface.ResumeLayout(false);
+            GroupPracticeUserInterface.PerformLayout();
+            GroupNearlyCorrect.ResumeLayout(false);
+            GroupNearlyCorrect.PerformLayout();
+            TabPracticeSelect.ResumeLayout(false);
+            GroupSelectionMix.ResumeLayout(false);
+            GroupSelectionMix.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox2).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox3).EndInit();
+            GroupRepetitions.ResumeLayout(false);
+            GroupRepetitions.PerformLayout();
+            PnlPracticeCount.ResumeLayout(false);
+            PnlPracticeCount.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)TrbRepetitions).EndInit();
+            ResumeLayout(false);
         }
 
         #endregion
@@ -660,7 +672,7 @@
         private System.Windows.Forms.CheckBox CbTolerateSpecialChar;
         private System.Windows.Forms.CheckBox CbToleratePunctuationMark;
         private System.Windows.Forms.CheckBox CbTolerateNoSynonym;
-        private System.Windows.Forms.GroupBox GroupUserInterface;
+        private System.Windows.Forms.GroupBox GroupPracticeUserInterface;
         private System.Windows.Forms.CheckBox CbSingleContinueButton;
         private System.Windows.Forms.CheckBox CbAcousticFeedback;
         private System.Windows.Forms.CheckBox CbManualCheck;
@@ -676,9 +688,11 @@
         private System.Windows.Forms.GroupBox GroupVocabularyList;
         private System.Windows.Forms.CheckBox CbColumnResize;
         private System.Windows.Forms.CheckBox CbTolerateWhiteSpace;
-        private System.Windows.Forms.GroupBox GroupLanguage;
+        private System.Windows.Forms.GroupBox GroupUserInterface;
         private System.Windows.Forms.Label LbLanguage;
         private System.Windows.Forms.ComboBox CbLanguage;
         private System.Windows.Forms.CheckBox CbOptionalExpressions;
+        private System.Windows.Forms.Label LbColorTheme;
+        private System.Windows.Forms.ComboBox CbColorTheme;
     }
 }

--- a/src/Vocup.WinForms/Forms/SettingsDialog.cs
+++ b/src/Vocup.WinForms/Forms/SettingsDialog.cs
@@ -33,6 +33,15 @@ public partial class SettingsDialog : Form
         TbVhfPath.Text = settings.VhfPath;
         TbVhrPath.Text = settings.VhrPath;
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        CbColorTheme.SelectedIndex = settings.ColorMode switch
+        {
+            SystemColorMode.Classic => 1,
+            SystemColorMode.Dark => 2,
+            _ => 0,
+        };
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         CbLanguage.SelectedIndex = settings.OverrideCulture switch
         {
             "en-US" => 1,
@@ -84,6 +93,16 @@ public partial class SettingsDialog : Form
         settings.VhfPath = TbVhfPath.Text;
         settings.VhrPath = TbVhrPath.Text;
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        SystemColorMode oldColorMode = settings.ColorMode;
+        settings.ColorMode = CbColorTheme.SelectedIndex switch
+        {
+            1 => SystemColorMode.Classic,
+            2 => SystemColorMode.Dark,
+            _ => SystemColorMode.System,
+        };
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         string? oldCulture = settings.OverrideCulture;
         settings.OverrideCulture = CbLanguage.SelectedIndex switch
         {
@@ -92,7 +111,7 @@ public partial class SettingsDialog : Form
             3 => "nl-NL",
             _ => null, // System language
         };
-        if (settings.OverrideCulture != oldCulture)
+        if (settings.ColorMode != oldColorMode || settings.OverrideCulture != oldCulture)
             MessageBox.Show(Messages.SettingsRestartRequired, Messages.SettingsRestartRequiredT, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
         // Evaluation

--- a/src/Vocup.WinForms/Forms/SettingsDialog.de.resx
+++ b/src/Vocup.WinForms/Forms/SettingsDialog.de.resx
@@ -117,122 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Einstellungen</value>
+  <data name="BtnOk.Text" xml:space="preserve">
+    <value>OK</value>
   </data>
   <data name="BtnCancel.Text" xml:space="preserve">
     <value>Abbrechen</value>
   </data>
-  <data name="BtnOk.Text" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="BtnResetPracticeSelect.Text" xml:space="preserve">
-    <value>Einstellungen zurücksetzen</value>
-  </data>
-  <data name="BtnResetStartScreen.Text" xml:space="preserve">
-    <value>Startbild zurücksetzen</value>
-  </data>
-  <data name="BtnVhfPath.Text" xml:space="preserve">
-    <value>Durchsuchen</value>
-  </data>
-  <data name="BtnVhrPath.Text" xml:space="preserve">
-    <value>Durchsuchen</value>
-  </data>
-  <data name="CbAcousticFeedback.Text" xml:space="preserve">
-    <value>Akustische Rückmeldungen aktivieren</value>
-  </data>
-  <data name="CbAutoSave.Text" xml:space="preserve">
-    <value>Vokabelheft bei Änderungen automatisch speichern</value>
-  </data>
-  <data name="CbColumnResize.Text" xml:space="preserve">
-    <value>Spaltenbreite automatisch anpassen</value>
-  </data>
-  <data name="CbDisableInternetServices.Text" xml:space="preserve">
-    <value>Internetdienste deaktivieren (nicht empfohlen)</value>
-  </data>
-  <data name="CbLanguage.Items" xml:space="preserve">
-    <value>Systemsprache</value>
-  </data>
-  <data name="CbLanguage.Items1" xml:space="preserve">
-    <value>Englisch</value>
-  </data>
-  <data name="CbLanguage.Items2" xml:space="preserve">
-    <value>Deutsch</value>
-  </data>
-  <data name="CbLanguage.Items3" xml:space="preserve">
-    <value>Niederländisch</value>
-  </data>
-  <data name="CbManualCheck.Text" xml:space="preserve">
-    <value>Übersetzungen beim Üben selbst bewerten</value>
-  </data>
-  <data name="CbOptionalExpressions.Text" xml:space="preserve">
-    <value>Ausdrücke in Klammers als optional behandeln</value>
-  </data>
-  <data name="CbShowPracticeResult.Text" xml:space="preserve">
-    <value>Nach einer Übung Auswertung anzeigen</value>
-  </data>
-  <data name="CbSingleContinueButton.Text" xml:space="preserve">
-    <value>Nach einer Übersetzung nur einmal Button betätigen</value>
-  </data>
-  <data name="CbTolerateArticle.Text" xml:space="preserve">
-    <value>falsche Artikel verwendet werden</value>
-  </data>
-  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
-    <value>nur eines von zwei Synonymen korrekt ist</value>
-  </data>
-  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
-    <value>Satzzeichen nicht stimmen</value>
-  </data>
-  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
-    <value>Sonderzeichen nicht stimmen</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
-    <value>die Leerzeichen nicht übereinstimmen</value>
-  </data>
-  <data name="GroupEvaluation.Text" xml:space="preserve">
-    <value>Auswertung</value>
-  </data>
-  <data name="GroupLanguage.Text" xml:space="preserve">
-    <value>Sprache</value>
-  </data>
-  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
-    <value>Als "Teilweise richtig" bewerten, wenn</value>
-  </data>
-  <data name="GroupSave.Text" xml:space="preserve">
-    <value>Speichern</value>
-  </data>
   <data name="GroupStartScreen.Text" xml:space="preserve">
     <value>Startbild</value>
   </data>
-  <data name="GroupUpdate.Text" xml:space="preserve">
-    <value>Updates</value>
-  </data>
-  <data name="GroupUserInterface.Text" xml:space="preserve">
-    <value>Benutzeroberfläche</value>
-  </data>
-  <data name="GroupVhfPath.Text" xml:space="preserve">
-    <value>Speicherpfad der Vokabelhefte</value>
-  </data>
-  <data name="GroupVhrPath.Text" xml:space="preserve">
-    <value>Speicherpfad der Ergebnisse</value>
-  </data>
-  <data name="GroupVocabularyList.Text" xml:space="preserve">
-    <value>Vokabelliste</value>
-  </data>
-  <data name="LbLanguage.Text" xml:space="preserve">
-    <value>Setze Oberflächensprache</value>
-  </data>
-  <data name="LbPercentageUnpracticed.Text" xml:space="preserve">
-    <value>Wie groß soll der Anteil an noch nicht geübten
- Vokabeln sein?</value>
-  </data>
-  <data name="LbPercentageWrongCorrect.Text" xml:space="preserve">
-    <value>Wie groß soll der Anteil an falsch und richtig geübten
- Vokabeln sein?</value>
-  </data>
-  <data name="LbPracticeCount.Text" xml:space="preserve">
-    <value>Wie oft muss eine Vokabel richtig übersetzt werden, 
-damit sie als gelernt eingestuft wird?</value>
+  <data name="BtnResetStartScreen.Text" xml:space="preserve">
+    <value>Startbild zurücksetzen</value>
   </data>
   <data name="RbEmptyStart.Text" xml:space="preserve">
     <value>Nichts anzeigen</value>
@@ -246,7 +141,112 @@ damit sie als gelernt eingestuft wird?</value>
   <data name="TabPractice.Text" xml:space="preserve">
     <value>Übungsoptionen</value>
   </data>
+  <data name="BtnResetPracticeSelect.Text" xml:space="preserve">
+    <value>Einstellungen zurücksetzen</value>
+  </data>
+  <data name="LbPercentageUnpracticed.Text" xml:space="preserve">
+    <value>Wie groß soll der Anteil an noch nicht geübten
+ Vokabeln sein?</value>
+  </data>
+  <data name="LbPercentageWrongCorrect.Text" xml:space="preserve">
+    <value>Wie groß soll der Anteil an falsch und richtig geübten
+ Vokabeln sein?</value>
+  </data>
+  <data name="LbPracticeCount.Text" xml:space="preserve">
+    <value>Wie oft muss eine Vokabel richtig übersetzt werden, 
+damit sie als gelernt eingestuft wird?</value>
+  </data>
   <data name="TabPracticeSelect.Text" xml:space="preserve">
     <value>Übungszusammensetzung</value>
+  </data>
+  <data name="LbLanguage.Text" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="CbLanguage.Items" xml:space="preserve">
+    <value>Systemsprache</value>
+  </data>
+  <data name="CbLanguage.Items1" xml:space="preserve">
+    <value>Englisch</value>
+  </data>
+  <data name="CbLanguage.Items2" xml:space="preserve">
+    <value>Deutsch</value>
+  </data>
+  <data name="CbLanguage.Items3" xml:space="preserve">
+    <value>Niederländisch</value>
+  </data>
+  <data name="GroupVocabularyList.Text" xml:space="preserve">
+    <value>Vokabelliste</value>
+  </data>
+  <data name="CbColumnResize.Text" xml:space="preserve">
+    <value>Spaltenbreite automatisch anpassen</value>
+  </data>
+  <data name="GroupVhrPath.Text" xml:space="preserve">
+    <value>Speicherpfad der Ergebnisse</value>
+  </data>
+  <data name="BtnVhrPath.Text" xml:space="preserve">
+    <value>Durchsuchen</value>
+  </data>
+  <data name="GroupVhfPath.Text" xml:space="preserve">
+    <value>Speicherpfad der Vokabelhefte</value>
+  </data>
+  <data name="BtnVhfPath.Text" xml:space="preserve">
+    <value>Durchsuchen</value>
+  </data>
+  <data name="GroupUpdate.Text" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="CbDisableInternetServices.Text" xml:space="preserve">
+    <value>Internetdienste deaktivieren (nicht empfohlen)</value>
+  </data>
+  <data name="GroupSave.Text" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="CbAutoSave.Text" xml:space="preserve">
+    <value>Vokabelheft bei Änderungen automatisch speichern</value>
+  </data>
+  <data name="GroupEvaluation.Text" xml:space="preserve">
+    <value>Auswertung</value>
+  </data>
+  <data name="CbOptionalExpressions.Text" xml:space="preserve">
+    <value>Ausdrücke in Klammers als optional behandeln</value>
+  </data>
+  <data name="CbManualCheck.Text" xml:space="preserve">
+    <value>Übersetzungen beim Üben selbst bewerten</value>
+  </data>
+  <data name="CbShowPracticeResult.Text" xml:space="preserve">
+    <value>Nach einer Übung Auswertung anzeigen</value>
+  </data>
+  <data name="GroupPracticeUserInterface.Text" xml:space="preserve">
+    <value>Benutzeroberfläche</value>
+  </data>
+  <data name="GroupUserInterface.Text" xml:space="preserve">
+    <value>Benutzeroberfläche</value>
+  </data>
+  <data name="CbAcousticFeedback.Text" xml:space="preserve">
+    <value>Akustische Rückmeldungen aktivieren</value>
+  </data>
+  <data name="CbSingleContinueButton.Text" xml:space="preserve">
+    <value>Nach einer Übersetzung nur einmal Button betätigen</value>
+  </data>
+  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
+    <value>Als "Teilweise richtig" bewerten, wenn</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
+    <value>die Leerzeichen nicht übereinstimmen</value>
+  </data>
+  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
+    <value>nur eines von zwei Synonymen korrekt ist</value>
+  </data>
+  <data name="CbTolerateArticle.Text" xml:space="preserve">
+    <value>falsche Artikel verwendet werden</value>
+  </data>
+  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
+    <value>Satzzeichen nicht stimmen</value>
+  </data>
+  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
+    <value>Sonderzeichen nicht stimmen</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Einstellungen</value>
   </data>
 </root>

--- a/src/Vocup.WinForms/Forms/SettingsDialog.nl.resx
+++ b/src/Vocup.WinForms/Forms/SettingsDialog.nl.resx
@@ -117,122 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Instellingen</value>
+  <data name="BtnOk.Text" xml:space="preserve">
+    <value>OK</value>
   </data>
   <data name="BtnCancel.Text" xml:space="preserve">
     <value>Annuleren</value>
   </data>
-  <data name="BtnOk.Text" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="BtnResetPracticeSelect.Text" xml:space="preserve">
-    <value>Instellingen terugzetten</value>
-  </data>
-  <data name="BtnResetStartScreen.Text" xml:space="preserve">
-    <value>Startscherm terugzetten</value>
-  </data>
-  <data name="BtnVhfPath.Text" xml:space="preserve">
-    <value>Bladeren</value>
-  </data>
-  <data name="BtnVhrPath.Text" xml:space="preserve">
-    <value>Bladeren</value>
-  </data>
-  <data name="CbAcousticFeedback.Text" xml:space="preserve">
-    <value>Akoestische feedback inschakelen</value>
-  </data>
-  <data name="CbAutoSave.Text" xml:space="preserve">
-    <value>Wijzigingen automatisch opslaan in woordenboek</value>
-  </data>
-  <data name="CbColumnResize.Text" xml:space="preserve">
-    <value>Kolombreedtes automatisch aanpassen</value>
-  </data>
-  <data name="CbDisableInternetServices.Text" xml:space="preserve">
-    <value>Internetdiensten deactiveren (niet aanbevolen)</value>
-  </data>
-  <data name="CbLanguage.Items" xml:space="preserve">
-    <value>Systeemtaal</value>
-  </data>
-  <data name="CbLanguage.Items1" xml:space="preserve">
-    <value>Engels</value>
-  </data>
-  <data name="CbLanguage.Items2" xml:space="preserve">
-    <value>Duits</value>
-  </data>
-  <data name="CbLanguage.Items3" xml:space="preserve">
-    <value>Nederlands</value>
-  </data>
-  <data name="CbManualCheck.Text" xml:space="preserve">
-    <value>Evalueer vertalingen zelf tijdens het oefenen</value>
-  </data>
-  <data name="CbOptionalExpressions.Text" xml:space="preserve">
-    <value>Tekst tussen haakjes als optioneel beschouwen</value>
-  </data>
-  <data name="CbShowPracticeResult.Text" xml:space="preserve">
-    <value>Resultaten tonen na oefenen</value>
-  </data>
-  <data name="CbSingleContinueButton.Text" xml:space="preserve">
-    <value>Knop slechts eenmaal indrukken na vertalen</value>
-  </data>
-  <data name="CbTolerateArticle.Text" xml:space="preserve">
-    <value>foute lidwoorden gebruikt zijn</value>
-  </data>
-  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
-    <value>slechts een van de twee synoniemen goed is</value>
-  </data>
-  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
-    <value>fouten met leestekens gemaakt zijn</value>
-  </data>
-  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
-    <value>fouten met speciale tekens gemaakt zijn</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
-    <value>fouten in witruimte gemaakt zijn</value>
-  </data>
-  <data name="GroupEvaluation.Text" xml:space="preserve">
-    <value>Evaluatie</value>
-  </data>
-  <data name="GroupLanguage.Text" xml:space="preserve">
-    <value>Taal</value>
-  </data>
-  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
-    <value>Als "Gedeeltelijk goed" markeren als</value>
-  </data>
-  <data name="GroupSave.Text" xml:space="preserve">
-    <value>Opslaan</value>
-  </data>
   <data name="GroupStartScreen.Text" xml:space="preserve">
     <value>Startscherm</value>
   </data>
-  <data name="GroupUpdate.Text" xml:space="preserve">
-    <value>Updates</value>
-  </data>
-  <data name="GroupUserInterface.Text" xml:space="preserve">
-    <value>User interface</value>
-  </data>
-  <data name="GroupVhfPath.Text" xml:space="preserve">
-    <value>Map voor woordenboeken</value>
-  </data>
-  <data name="GroupVhrPath.Text" xml:space="preserve">
-    <value>Map voor resultaatbestanden</value>
-  </data>
-  <data name="GroupVocabularyList.Text" xml:space="preserve">
-    <value>Woordenlijst</value>
-  </data>
-  <data name="LbLanguage.Text" xml:space="preserve">
-    <value>Taal instellen</value>
-  </data>
-  <data name="LbPercentageUnpracticed.Text" xml:space="preserve">
-    <value>Welk percentage van ongeoefende woorden
-wil je hebben?</value>
-  </data>
-  <data name="LbPercentageWrongCorrect.Text" xml:space="preserve">
-    <value>Welk percentage van fout en goed beantwoorde
-woorden wil je hebben?</value>
-  </data>
-  <data name="LbPracticeCount.Text" xml:space="preserve">
-    <value>Hoe vaak moet een woord goed vertaald worden
-voordat het als geleerd wordt gezien?</value>
+  <data name="BtnResetStartScreen.Text" xml:space="preserve">
+    <value>Startscherm terugzetten</value>
   </data>
   <data name="RbEmptyStart.Text" xml:space="preserve">
     <value>Leeg scherm</value>
@@ -246,7 +141,112 @@ voordat het als geleerd wordt gezien?</value>
   <data name="TabPractice.Text" xml:space="preserve">
     <value>Oefen instellingen</value>
   </data>
+  <data name="BtnResetPracticeSelect.Text" xml:space="preserve">
+    <value>Instellingen terugzetten</value>
+  </data>
+  <data name="LbPercentageUnpracticed.Text" xml:space="preserve">
+    <value>Welk percentage van ongeoefende woorden
+wil je hebben?</value>
+  </data>
+  <data name="LbPercentageWrongCorrect.Text" xml:space="preserve">
+    <value>Welk percentage van fout en goed beantwoorde
+woorden wil je hebben?</value>
+  </data>
+  <data name="LbPracticeCount.Text" xml:space="preserve">
+    <value>Hoe vaak moet een woord goed vertaald worden
+voordat het als geleerd wordt gezien?</value>
+  </data>
   <data name="TabPracticeSelect.Text" xml:space="preserve">
     <value>Oefen samenstelling</value>
+  </data>
+  <data name="LbLanguage.Text" xml:space="preserve">
+    <value>Taal</value>
+  </data>
+  <data name="CbLanguage.Items" xml:space="preserve">
+    <value>Systeemtaal</value>
+  </data>
+  <data name="CbLanguage.Items1" xml:space="preserve">
+    <value>Engels</value>
+  </data>
+  <data name="CbLanguage.Items2" xml:space="preserve">
+    <value>Duits</value>
+  </data>
+  <data name="CbLanguage.Items3" xml:space="preserve">
+    <value>Nederlands</value>
+  </data>
+  <data name="GroupVocabularyList.Text" xml:space="preserve">
+    <value>Woordenlijst</value>
+  </data>
+  <data name="CbColumnResize.Text" xml:space="preserve">
+    <value>Kolombreedtes automatisch aanpassen</value>
+  </data>
+  <data name="GroupVhrPath.Text" xml:space="preserve">
+    <value>Map voor resultaatbestanden</value>
+  </data>
+  <data name="BtnVhrPath.Text" xml:space="preserve">
+    <value>Bladeren</value>
+  </data>
+  <data name="GroupVhfPath.Text" xml:space="preserve">
+    <value>Map voor woordenboeken</value>
+  </data>
+  <data name="BtnVhfPath.Text" xml:space="preserve">
+    <value>Bladeren</value>
+  </data>
+  <data name="GroupUpdate.Text" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="CbDisableInternetServices.Text" xml:space="preserve">
+    <value>Internetdiensten deactiveren (niet aanbevolen)</value>
+  </data>
+  <data name="GroupSave.Text" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="CbAutoSave.Text" xml:space="preserve">
+    <value>Wijzigingen automatisch opslaan in woordenboek</value>
+  </data>
+  <data name="GroupEvaluation.Text" xml:space="preserve">
+    <value>Evaluatie</value>
+  </data>
+  <data name="CbOptionalExpressions.Text" xml:space="preserve">
+    <value>Tekst tussen haakjes als optioneel beschouwen</value>
+  </data>
+  <data name="CbManualCheck.Text" xml:space="preserve">
+    <value>Evalueer vertalingen zelf tijdens het oefenen</value>
+  </data>
+  <data name="CbShowPracticeResult.Text" xml:space="preserve">
+    <value>Resultaten tonen na oefenen</value>
+  </data>
+  <data name="GroupPracticeUserInterface.Text" xml:space="preserve">
+    <value>User interface</value>
+  </data>
+  <data name="GroupUserInterface.Text" xml:space="preserve">
+    <value>User interface</value>
+  </data>
+  <data name="CbAcousticFeedback.Text" xml:space="preserve">
+    <value>Akoestische feedback inschakelen</value>
+  </data>
+  <data name="CbSingleContinueButton.Text" xml:space="preserve">
+    <value>Knop slechts eenmaal indrukken na vertalen</value>
+  </data>
+  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
+    <value>Als "Gedeeltelijk goed" markeren als</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
+    <value>fouten in witruimte gemaakt zijn</value>
+  </data>
+  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
+    <value>slechts een van de twee synoniemen goed is</value>
+  </data>
+  <data name="CbTolerateArticle.Text" xml:space="preserve">
+    <value>foute lidwoorden gebruikt zijn</value>
+  </data>
+  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
+    <value>fouten met leestekens gemaakt zijn</value>
+  </data>
+  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
+    <value>fouten met speciale tekens gemaakt zijn</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Instellingen</value>
   </data>
 </root>

--- a/src/Vocup.WinForms/Forms/SettingsDialog.resx
+++ b/src/Vocup.WinForms/Forms/SettingsDialog.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="BtnOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="BtnOk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 434</value>
+    <value>151, 454</value>
   </data>
   <data name="BtnOk.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -151,7 +151,7 @@
     <value>Bottom, Right</value>
   </data>
   <data name="BtnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 434</value>
+    <value>232, 454</value>
   </data>
   <data name="BtnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -174,6 +174,18 @@
   <data name="&gt;&gt;BtnCancel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="BtnResetStartScreen.Location" type="System.Drawing.Point, System.Drawing">
+    <value>197, 36</value>
+  </data>
+  <data name="BtnResetStartScreen.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="BtnResetStartScreen.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="BtnResetStartScreen.Text" xml:space="preserve">
+    <value>Reset</value>
+  </data>
   <data name="&gt;&gt;BtnResetStartScreen.Name" xml:space="preserve">
     <value>BtnResetStartScreen</value>
   </data>
@@ -186,6 +198,21 @@
   <data name="&gt;&gt;BtnResetStartScreen.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="RbEmptyStart.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RbEmptyStart.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="RbEmptyStart.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 17</value>
+  </data>
+  <data name="RbEmptyStart.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="RbEmptyStart.Text" xml:space="preserve">
+    <value>Empty window</value>
+  </data>
   <data name="&gt;&gt;RbEmptyStart.Name" xml:space="preserve">
     <value>RbEmptyStart</value>
   </data>
@@ -197,6 +224,21 @@
   </data>
   <data name="&gt;&gt;RbEmptyStart.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="RbRecentFile.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RbRecentFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="RbRecentFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 17</value>
+  </data>
+  <data name="RbRecentFile.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="RbRecentFile.Text" xml:space="preserve">
+    <value>Recent vocabulary book</value>
   </data>
   <data name="&gt;&gt;RbRecentFile.Name" xml:space="preserve">
     <value>RbRecentFile</value>
@@ -233,48 +275,6 @@
   </data>
   <data name="&gt;&gt;GroupStartScreen.ZOrder" xml:space="preserve">
     <value>6</value>
-  </data>
-  <data name="BtnResetStartScreen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>197, 36</value>
-  </data>
-  <data name="BtnResetStartScreen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="BtnResetStartScreen.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="BtnResetStartScreen.Text" xml:space="preserve">
-    <value>Reset</value>
-  </data>
-  <data name="RbEmptyStart.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RbEmptyStart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="RbEmptyStart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
-  </data>
-  <data name="RbEmptyStart.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="RbEmptyStart.Text" xml:space="preserve">
-    <value>Empty window</value>
-  </data>
-  <data name="RbRecentFile.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RbRecentFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="RbRecentFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
-  </data>
-  <data name="RbRecentFile.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="RbRecentFile.Text" xml:space="preserve">
-    <value>Recent vocabulary book</value>
   </data>
   <data name="TrbWrongRight.Location" type="System.Drawing.Point, System.Drawing">
     <value>67, 129</value>
@@ -318,17 +318,191 @@
   <data name="&gt;&gt;TrbUnknown.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;GroupLanguage.Name" xml:space="preserve">
-    <value>GroupLanguage</value>
+  <data name="CbColorTheme.Items" xml:space="preserve">
+    <value>System</value>
   </data>
-  <data name="&gt;&gt;GroupLanguage.Type" xml:space="preserve">
+  <data name="CbColorTheme.Items1" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="CbColorTheme.Items2" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <data name="CbColorTheme.Location" type="System.Drawing.Point, System.Drawing">
+    <value>150, 19</value>
+  </data>
+  <data name="CbColorTheme.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="CbColorTheme.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;CbColorTheme.Name" xml:space="preserve">
+    <value>CbColorTheme</value>
+  </data>
+  <data name="&gt;&gt;CbColorTheme.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbColorTheme.Parent" xml:space="preserve">
+    <value>GroupUserInterface</value>
+  </data>
+  <data name="&gt;&gt;CbColorTheme.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="LbColorTheme.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbColorTheme.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LbColorTheme.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 22</value>
+  </data>
+  <data name="LbColorTheme.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 13</value>
+  </data>
+  <data name="LbColorTheme.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="LbColorTheme.Text" xml:space="preserve">
+    <value>Color theme</value>
+  </data>
+  <data name="&gt;&gt;LbColorTheme.Name" xml:space="preserve">
+    <value>LbColorTheme</value>
+  </data>
+  <data name="&gt;&gt;LbColorTheme.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LbColorTheme.Parent" xml:space="preserve">
+    <value>GroupUserInterface</value>
+  </data>
+  <data name="&gt;&gt;LbColorTheme.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="LbLanguage.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbLanguage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 49</value>
+  </data>
+  <data name="LbLanguage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 13</value>
+  </data>
+  <data name="LbLanguage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="LbLanguage.Text" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="&gt;&gt;LbLanguage.Name" xml:space="preserve">
+    <value>LbLanguage</value>
+  </data>
+  <data name="&gt;&gt;LbLanguage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LbLanguage.Parent" xml:space="preserve">
+    <value>GroupUserInterface</value>
+  </data>
+  <data name="&gt;&gt;LbLanguage.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="CbLanguage.Items" xml:space="preserve">
+    <value>System language</value>
+  </data>
+  <data name="CbLanguage.Items1" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="CbLanguage.Items2" xml:space="preserve">
+    <value>German</value>
+  </data>
+  <data name="CbLanguage.Items3" xml:space="preserve">
+    <value>Dutch</value>
+  </data>
+  <data name="CbLanguage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>150, 46</value>
+  </data>
+  <data name="CbLanguage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="CbLanguage.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CbLanguage.Name" xml:space="preserve">
+    <value>CbLanguage</value>
+  </data>
+  <data name="&gt;&gt;CbLanguage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbLanguage.Parent" xml:space="preserve">
+    <value>GroupUserInterface</value>
+  </data>
+  <data name="&gt;&gt;CbLanguage.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="GroupUserInterface.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 337</value>
+  </data>
+  <data name="GroupUserInterface.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 74</value>
+  </data>
+  <data name="GroupUserInterface.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="GroupUserInterface.Text" xml:space="preserve">
+    <value>User interface</value>
+  </data>
+  <data name="&gt;&gt;GroupUserInterface.Name" xml:space="preserve">
+    <value>GroupUserInterface</value>
+  </data>
+  <data name="&gt;&gt;GroupUserInterface.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;GroupLanguage.Parent" xml:space="preserve">
+  <data name="&gt;&gt;GroupUserInterface.Parent" xml:space="preserve">
     <value>TabGeneral</value>
   </data>
-  <data name="&gt;&gt;GroupLanguage.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;GroupUserInterface.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="CbColumnResize.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbColumnResize.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbColumnResize.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="CbColumnResize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 17</value>
+  </data>
+  <data name="CbColumnResize.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="CbColumnResize.Text" xml:space="preserve">
+    <value>Automatically resize columns</value>
+  </data>
+  <data name="&gt;&gt;CbColumnResize.Name" xml:space="preserve">
+    <value>CbColumnResize</value>
+  </data>
+  <data name="&gt;&gt;CbColumnResize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbColumnResize.Parent" xml:space="preserve">
+    <value>GroupVocabularyList</value>
+  </data>
+  <data name="&gt;&gt;CbColumnResize.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GroupVocabularyList.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 181</value>
+  </data>
+  <data name="GroupVocabularyList.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 42</value>
+  </data>
+  <data name="GroupVocabularyList.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="GroupVocabularyList.Text" xml:space="preserve">
+    <value>Vocabulary list</value>
   </data>
   <data name="&gt;&gt;GroupVocabularyList.Name" xml:space="preserve">
     <value>GroupVocabularyList</value>
@@ -342,6 +516,66 @@
   <data name="&gt;&gt;GroupVocabularyList.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="BtnVhrPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BtnVhrPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>189, 17</value>
+  </data>
+  <data name="BtnVhrPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 23</value>
+  </data>
+  <data name="BtnVhrPath.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="BtnVhrPath.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="&gt;&gt;BtnVhrPath.Name" xml:space="preserve">
+    <value>BtnVhrPath</value>
+  </data>
+  <data name="&gt;&gt;BtnVhrPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnVhrPath.Parent" xml:space="preserve">
+    <value>GroupVhrPath</value>
+  </data>
+  <data name="&gt;&gt;BtnVhrPath.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="TbVhrPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="TbVhrPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 20</value>
+  </data>
+  <data name="TbVhrPath.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;TbVhrPath.Name" xml:space="preserve">
+    <value>TbVhrPath</value>
+  </data>
+  <data name="&gt;&gt;TbVhrPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TbVhrPath.Parent" xml:space="preserve">
+    <value>GroupVhrPath</value>
+  </data>
+  <data name="&gt;&gt;TbVhrPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GroupVhrPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 284</value>
+  </data>
+  <data name="GroupVhrPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 45</value>
+  </data>
+  <data name="GroupVhrPath.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="GroupVhrPath.Text" xml:space="preserve">
+    <value>Folder for practice results</value>
+  </data>
   <data name="&gt;&gt;GroupVhrPath.Name" xml:space="preserve">
     <value>GroupVhrPath</value>
   </data>
@@ -353,6 +587,63 @@
   </data>
   <data name="&gt;&gt;GroupVhrPath.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="BtnVhfPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>189, 17</value>
+  </data>
+  <data name="BtnVhfPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 23</value>
+  </data>
+  <data name="BtnVhfPath.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="BtnVhfPath.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="&gt;&gt;BtnVhfPath.Name" xml:space="preserve">
+    <value>BtnVhfPath</value>
+  </data>
+  <data name="&gt;&gt;BtnVhfPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnVhfPath.Parent" xml:space="preserve">
+    <value>GroupVhfPath</value>
+  </data>
+  <data name="&gt;&gt;BtnVhfPath.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="TbVhfPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="TbVhfPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 20</value>
+  </data>
+  <data name="TbVhfPath.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;TbVhfPath.Name" xml:space="preserve">
+    <value>TbVhfPath</value>
+  </data>
+  <data name="&gt;&gt;TbVhfPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TbVhfPath.Parent" xml:space="preserve">
+    <value>GroupVhfPath</value>
+  </data>
+  <data name="&gt;&gt;TbVhfPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GroupVhfPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 231</value>
+  </data>
+  <data name="GroupVhfPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 45</value>
+  </data>
+  <data name="GroupVhfPath.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="GroupVhfPath.Text" xml:space="preserve">
+    <value>Folder for vocabulary books</value>
   </data>
   <data name="&gt;&gt;GroupVhfPath.Name" xml:space="preserve">
     <value>GroupVhfPath</value>
@@ -366,6 +657,45 @@
   <data name="&gt;&gt;GroupVhfPath.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="CbDisableInternetServices.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbDisableInternetServices.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="CbDisableInternetServices.Size" type="System.Drawing.Size, System.Drawing">
+    <value>236, 17</value>
+  </data>
+  <data name="CbDisableInternetServices.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CbDisableInternetServices.Text" xml:space="preserve">
+    <value>Disable Internet services (not recommended)</value>
+  </data>
+  <data name="&gt;&gt;CbDisableInternetServices.Name" xml:space="preserve">
+    <value>CbDisableInternetServices</value>
+  </data>
+  <data name="&gt;&gt;CbDisableInternetServices.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbDisableInternetServices.Parent" xml:space="preserve">
+    <value>GroupUpdate</value>
+  </data>
+  <data name="&gt;&gt;CbDisableInternetServices.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GroupUpdate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 131</value>
+  </data>
+  <data name="GroupUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 42</value>
+  </data>
+  <data name="GroupUpdate.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="GroupUpdate.Text" xml:space="preserve">
+    <value>Updates</value>
+  </data>
   <data name="&gt;&gt;GroupUpdate.Name" xml:space="preserve">
     <value>GroupUpdate</value>
   </data>
@@ -377,6 +707,45 @@
   </data>
   <data name="&gt;&gt;GroupUpdate.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="CbAutoSave.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbAutoSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="CbAutoSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>274, 17</value>
+  </data>
+  <data name="CbAutoSave.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CbAutoSave.Text" xml:space="preserve">
+    <value>Automatically save changes in your vocabulary book</value>
+  </data>
+  <data name="&gt;&gt;CbAutoSave.Name" xml:space="preserve">
+    <value>CbAutoSave</value>
+  </data>
+  <data name="&gt;&gt;CbAutoSave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbAutoSave.Parent" xml:space="preserve">
+    <value>GroupSave</value>
+  </data>
+  <data name="&gt;&gt;CbAutoSave.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GroupSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 81</value>
+  </data>
+  <data name="GroupSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 42</value>
+  </data>
+  <data name="GroupSave.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="GroupSave.Text" xml:space="preserve">
+    <value>Save</value>
   </data>
   <data name="&gt;&gt;GroupSave.Name" xml:space="preserve">
     <value>GroupSave</value>
@@ -393,11 +762,12 @@
   <data name="TabGeneral.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="TabGeneral.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
   <data name="TabGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 397</value>
+    <value>289, 417</value>
   </data>
   <data name="TabGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -417,6 +787,108 @@
   <data name="&gt;&gt;TabGeneral.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="CbOptionalExpressions.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbOptionalExpressions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbOptionalExpressions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 65</value>
+  </data>
+  <data name="CbOptionalExpressions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>235, 17</value>
+  </data>
+  <data name="CbOptionalExpressions.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="CbOptionalExpressions.Text" xml:space="preserve">
+    <value>Treat expressions in parantheses as optional</value>
+  </data>
+  <data name="&gt;&gt;CbOptionalExpressions.Name" xml:space="preserve">
+    <value>CbOptionalExpressions</value>
+  </data>
+  <data name="&gt;&gt;CbOptionalExpressions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbOptionalExpressions.Parent" xml:space="preserve">
+    <value>GroupEvaluation</value>
+  </data>
+  <data name="&gt;&gt;CbOptionalExpressions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CbManualCheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbManualCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbManualCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="CbManualCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>222, 17</value>
+  </data>
+  <data name="CbManualCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CbManualCheck.Text" xml:space="preserve">
+    <value>Self-evaluate translations when practicing</value>
+  </data>
+  <data name="&gt;&gt;CbManualCheck.Name" xml:space="preserve">
+    <value>CbManualCheck</value>
+  </data>
+  <data name="&gt;&gt;CbManualCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbManualCheck.Parent" xml:space="preserve">
+    <value>GroupEvaluation</value>
+  </data>
+  <data name="&gt;&gt;CbManualCheck.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CbShowPracticeResult.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbShowPracticeResult.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbShowPracticeResult.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="CbShowPracticeResult.Size" type="System.Drawing.Size, System.Drawing">
+    <value>159, 17</value>
+  </data>
+  <data name="CbShowPracticeResult.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CbShowPracticeResult.Text" xml:space="preserve">
+    <value>Show results after practicing</value>
+  </data>
+  <data name="&gt;&gt;CbShowPracticeResult.Name" xml:space="preserve">
+    <value>CbShowPracticeResult</value>
+  </data>
+  <data name="&gt;&gt;CbShowPracticeResult.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbShowPracticeResult.Parent" xml:space="preserve">
+    <value>GroupEvaluation</value>
+  </data>
+  <data name="&gt;&gt;CbShowPracticeResult.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="GroupEvaluation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 8</value>
+  </data>
+  <data name="GroupEvaluation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 88</value>
+  </data>
+  <data name="GroupEvaluation.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="GroupEvaluation.Text" xml:space="preserve">
+    <value>Evaluation</value>
+  </data>
   <data name="&gt;&gt;GroupEvaluation.Name" xml:space="preserve">
     <value>GroupEvaluation</value>
   </data>
@@ -429,17 +901,245 @@
   <data name="&gt;&gt;GroupEvaluation.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;GroupUserInterface.Name" xml:space="preserve">
-    <value>GroupUserInterface</value>
+  <data name="CbAcousticFeedback.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;GroupUserInterface.Type" xml:space="preserve">
+  <data name="CbAcousticFeedback.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="CbAcousticFeedback.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 17</value>
+  </data>
+  <data name="CbAcousticFeedback.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CbAcousticFeedback.Text" xml:space="preserve">
+    <value>Enable acoustic feedback</value>
+  </data>
+  <data name="&gt;&gt;CbAcousticFeedback.Name" xml:space="preserve">
+    <value>CbAcousticFeedback</value>
+  </data>
+  <data name="&gt;&gt;CbAcousticFeedback.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbAcousticFeedback.Parent" xml:space="preserve">
+    <value>GroupPracticeUserInterface</value>
+  </data>
+  <data name="&gt;&gt;CbAcousticFeedback.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CbSingleContinueButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbSingleContinueButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="CbSingleContinueButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 17</value>
+  </data>
+  <data name="CbSingleContinueButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CbSingleContinueButton.Text" xml:space="preserve">
+    <value>Press button only once after transalting</value>
+  </data>
+  <data name="&gt;&gt;CbSingleContinueButton.Name" xml:space="preserve">
+    <value>CbSingleContinueButton</value>
+  </data>
+  <data name="&gt;&gt;CbSingleContinueButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbSingleContinueButton.Parent" xml:space="preserve">
+    <value>GroupPracticeUserInterface</value>
+  </data>
+  <data name="&gt;&gt;CbSingleContinueButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GroupPracticeUserInterface.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 251</value>
+  </data>
+  <data name="GroupPracticeUserInterface.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 64</value>
+  </data>
+  <data name="GroupPracticeUserInterface.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="GroupPracticeUserInterface.Text" xml:space="preserve">
+    <value>User interface</value>
+  </data>
+  <data name="&gt;&gt;GroupPracticeUserInterface.Name" xml:space="preserve">
+    <value>GroupPracticeUserInterface</value>
+  </data>
+  <data name="&gt;&gt;GroupPracticeUserInterface.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;GroupUserInterface.Parent" xml:space="preserve">
+  <data name="&gt;&gt;GroupPracticeUserInterface.Parent" xml:space="preserve">
     <value>TabPractice</value>
   </data>
-  <data name="&gt;&gt;GroupUserInterface.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;GroupPracticeUserInterface.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 17</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
+    <value>whitespaces do not match</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateWhiteSpace.Name" xml:space="preserve">
+    <value>CbTolerateWhiteSpace</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateWhiteSpace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateWhiteSpace.Parent" xml:space="preserve">
+    <value>GroupNearlyCorrect</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateWhiteSpace.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CbTolerateNoSynonym.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbTolerateNoSynonym.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbTolerateNoSynonym.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 111</value>
+  </data>
+  <data name="CbTolerateNoSynonym.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 17</value>
+  </data>
+  <data name="CbTolerateNoSynonym.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
+    <value>only one of two synonyms is correct</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateNoSynonym.Name" xml:space="preserve">
+    <value>CbTolerateNoSynonym</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateNoSynonym.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateNoSynonym.Parent" xml:space="preserve">
+    <value>GroupNearlyCorrect</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateNoSynonym.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CbTolerateArticle.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbTolerateArticle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbTolerateArticle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 88</value>
+  </data>
+  <data name="CbTolerateArticle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>171, 17</value>
+  </data>
+  <data name="CbTolerateArticle.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="CbTolerateArticle.Text" xml:space="preserve">
+    <value>wrong articles have been used</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateArticle.Name" xml:space="preserve">
+    <value>CbTolerateArticle</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateArticle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateArticle.Parent" xml:space="preserve">
+    <value>GroupNearlyCorrect</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateArticle.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="CbToleratePunctuationMark.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbToleratePunctuationMark.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbToleratePunctuationMark.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="CbToleratePunctuationMark.Size" type="System.Drawing.Size, System.Drawing">
+    <value>175, 17</value>
+  </data>
+  <data name="CbToleratePunctuationMark.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
+    <value>punctuation marks are incorrect</value>
+  </data>
+  <data name="&gt;&gt;CbToleratePunctuationMark.Name" xml:space="preserve">
+    <value>CbToleratePunctuationMark</value>
+  </data>
+  <data name="&gt;&gt;CbToleratePunctuationMark.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbToleratePunctuationMark.Parent" xml:space="preserve">
+    <value>GroupNearlyCorrect</value>
+  </data>
+  <data name="&gt;&gt;CbToleratePunctuationMark.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="CbTolerateSpecialChar.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CbTolerateSpecialChar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CbTolerateSpecialChar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 65</value>
+  </data>
+  <data name="CbTolerateSpecialChar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 17</value>
+  </data>
+  <data name="CbTolerateSpecialChar.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
+    <value>special chars are incorrect</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateSpecialChar.Name" xml:space="preserve">
+    <value>CbTolerateSpecialChar</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateSpecialChar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateSpecialChar.Parent" xml:space="preserve">
+    <value>GroupNearlyCorrect</value>
+  </data>
+  <data name="&gt;&gt;CbTolerateSpecialChar.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="GroupNearlyCorrect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 107</value>
+  </data>
+  <data name="GroupNearlyCorrect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 133</value>
+  </data>
+  <data name="GroupNearlyCorrect.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
+    <value>Mark as "Partly correct" when</value>
   </data>
   <data name="&gt;&gt;GroupNearlyCorrect.Name" xml:space="preserve">
     <value>GroupNearlyCorrect</value>
@@ -460,7 +1160,7 @@
     <value>3, 3, 3, 3</value>
   </data>
   <data name="TabPractice.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 397</value>
+    <value>289, 417</value>
   </data>
   <data name="TabPractice.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -765,6 +1465,21 @@
   <data name="&gt;&gt;LbPracticeCount.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="LbTrb6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbTrb6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>155, 35</value>
+  </data>
+  <data name="LbTrb6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="LbTrb6.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="LbTrb6.Text" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="&gt;&gt;LbTrb6.Name" xml:space="preserve">
     <value>LbTrb6</value>
   </data>
@@ -776,6 +1491,21 @@
   </data>
   <data name="&gt;&gt;LbTrb6.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="LbTrb2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbTrb2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 35</value>
+  </data>
+  <data name="LbTrb2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="LbTrb2.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="LbTrb2.Text" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="&gt;&gt;LbTrb2.Name" xml:space="preserve">
     <value>LbTrb2</value>
@@ -789,6 +1519,21 @@
   <data name="&gt;&gt;LbTrb2.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="LbTrb5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbTrb5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>119, 35</value>
+  </data>
+  <data name="LbTrb5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="LbTrb5.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="LbTrb5.Text" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="&gt;&gt;LbTrb5.Name" xml:space="preserve">
     <value>LbTrb5</value>
   </data>
@@ -800,6 +1545,21 @@
   </data>
   <data name="&gt;&gt;LbTrb5.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="LbTrb3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbTrb3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>45, 35</value>
+  </data>
+  <data name="LbTrb3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="LbTrb3.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="LbTrb3.Text" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="&gt;&gt;LbTrb3.Name" xml:space="preserve">
     <value>LbTrb3</value>
@@ -813,6 +1573,21 @@
   <data name="&gt;&gt;LbTrb3.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="LbTrb4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LbTrb4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>82, 35</value>
+  </data>
+  <data name="LbTrb4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="LbTrb4.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="LbTrb4.Text" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="&gt;&gt;LbTrb4.Name" xml:space="preserve">
     <value>LbTrb4</value>
   </data>
@@ -824,6 +1599,15 @@
   </data>
   <data name="&gt;&gt;LbTrb4.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="TrbRepetitions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="TrbRepetitions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>172, 45</value>
+  </data>
+  <data name="TrbRepetitions.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="&gt;&gt;TrbRepetitions.Name" xml:space="preserve">
     <value>TrbRepetitions</value>
@@ -886,7 +1670,7 @@
     <value>3, 3, 3, 3</value>
   </data>
   <data name="TabPracticeSelect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 397</value>
+    <value>289, 417</value>
   </data>
   <data name="TabPracticeSelect.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -910,7 +1694,7 @@
     <value>10, 5</value>
   </data>
   <data name="TabControlMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 423</value>
+    <value>297, 443</value>
   </data>
   <data name="TabControlMain.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -927,737 +1711,14 @@
   <data name="&gt;&gt;TabControlMain.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;LbLanguage.Name" xml:space="preserve">
-    <value>LbLanguage</value>
-  </data>
-  <data name="&gt;&gt;LbLanguage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LbLanguage.Parent" xml:space="preserve">
-    <value>GroupLanguage</value>
-  </data>
-  <data name="&gt;&gt;LbLanguage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CbLanguage.Name" xml:space="preserve">
-    <value>CbLanguage</value>
-  </data>
-  <data name="&gt;&gt;CbLanguage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbLanguage.Parent" xml:space="preserve">
-    <value>GroupLanguage</value>
-  </data>
-  <data name="&gt;&gt;CbLanguage.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GroupLanguage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 337</value>
-  </data>
-  <data name="GroupLanguage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 45</value>
-  </data>
-  <data name="GroupLanguage.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="GroupLanguage.Text" xml:space="preserve">
-    <value>Language</value>
-  </data>
-  <data name="LbLanguage.AutoSize" type="System.Boolean, mscorlib">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
-  </data>
-  <data name="LbLanguage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
-  </data>
-  <data name="LbLanguage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 13</value>
-  </data>
-  <data name="LbLanguage.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="LbLanguage.Text" xml:space="preserve">
-    <value>Set user interface culture</value>
-  </data>
-  <data name="CbLanguage.Items" xml:space="preserve">
-    <value>System language</value>
-  </data>
-  <data name="CbLanguage.Items1" xml:space="preserve">
-    <value>English</value>
-  </data>
-  <data name="CbLanguage.Items2" xml:space="preserve">
-    <value>German</value>
-  </data>
-  <data name="CbLanguage.Items3" xml:space="preserve">
-    <value>Dutch</value>
-  </data>
-  <data name="CbLanguage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 19</value>
-  </data>
-  <data name="CbLanguage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
-  </data>
-  <data name="CbLanguage.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CbColumnResize.Name" xml:space="preserve">
-    <value>CbColumnResize</value>
-  </data>
-  <data name="&gt;&gt;CbColumnResize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbColumnResize.Parent" xml:space="preserve">
-    <value>GroupVocabularyList</value>
-  </data>
-  <data name="&gt;&gt;CbColumnResize.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="GroupVocabularyList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 181</value>
-  </data>
-  <data name="GroupVocabularyList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 42</value>
-  </data>
-  <data name="GroupVocabularyList.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="GroupVocabularyList.Text" xml:space="preserve">
-    <value>Vocabulary list</value>
-  </data>
-  <data name="CbColumnResize.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbColumnResize.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbColumnResize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="CbColumnResize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 17</value>
-  </data>
-  <data name="CbColumnResize.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="CbColumnResize.Text" xml:space="preserve">
-    <value>Automatically resize columns</value>
-  </data>
-  <data name="&gt;&gt;BtnVhrPath.Name" xml:space="preserve">
-    <value>BtnVhrPath</value>
-  </data>
-  <data name="&gt;&gt;BtnVhrPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BtnVhrPath.Parent" xml:space="preserve">
-    <value>GroupVhrPath</value>
-  </data>
-  <data name="&gt;&gt;BtnVhrPath.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;TbVhrPath.Name" xml:space="preserve">
-    <value>TbVhrPath</value>
-  </data>
-  <data name="&gt;&gt;TbVhrPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TbVhrPath.Parent" xml:space="preserve">
-    <value>GroupVhrPath</value>
-  </data>
-  <data name="&gt;&gt;TbVhrPath.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GroupVhrPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 284</value>
-  </data>
-  <data name="GroupVhrPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 45</value>
-  </data>
-  <data name="GroupVhrPath.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="GroupVhrPath.Text" xml:space="preserve">
-    <value>Folder for practice results</value>
-  </data>
-  <data name="BtnVhrPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="BtnVhrPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 17</value>
-  </data>
-  <data name="BtnVhrPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 23</value>
-  </data>
-  <data name="BtnVhrPath.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="BtnVhrPath.Text" xml:space="preserve">
-    <value>Browse</value>
-  </data>
-  <data name="TbVhrPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="TbVhrPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 20</value>
-  </data>
-  <data name="TbVhrPath.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;BtnVhfPath.Name" xml:space="preserve">
-    <value>BtnVhfPath</value>
-  </data>
-  <data name="&gt;&gt;BtnVhfPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BtnVhfPath.Parent" xml:space="preserve">
-    <value>GroupVhfPath</value>
-  </data>
-  <data name="&gt;&gt;BtnVhfPath.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;TbVhfPath.Name" xml:space="preserve">
-    <value>TbVhfPath</value>
-  </data>
-  <data name="&gt;&gt;TbVhfPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TbVhfPath.Parent" xml:space="preserve">
-    <value>GroupVhfPath</value>
-  </data>
-  <data name="&gt;&gt;TbVhfPath.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GroupVhfPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 231</value>
-  </data>
-  <data name="GroupVhfPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 45</value>
-  </data>
-  <data name="GroupVhfPath.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="GroupVhfPath.Text" xml:space="preserve">
-    <value>Folder for vocabulary books</value>
-  </data>
-  <data name="BtnVhfPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 17</value>
-  </data>
-  <data name="BtnVhfPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 23</value>
-  </data>
-  <data name="BtnVhfPath.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="BtnVhfPath.Text" xml:space="preserve">
-    <value>Browse</value>
-  </data>
-  <data name="TbVhfPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="TbVhfPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 20</value>
-  </data>
-  <data name="TbVhfPath.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CbDisableInternetServices.Name" xml:space="preserve">
-    <value>CbDisableInternetServices</value>
-  </data>
-  <data name="&gt;&gt;CbDisableInternetServices.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbDisableInternetServices.Parent" xml:space="preserve">
-    <value>GroupUpdate</value>
-  </data>
-  <data name="&gt;&gt;CbDisableInternetServices.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="GroupUpdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 131</value>
-  </data>
-  <data name="GroupUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 42</value>
-  </data>
-  <data name="GroupUpdate.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="GroupUpdate.Text" xml:space="preserve">
-    <value>Updates</value>
-  </data>
-  <data name="CbDisableInternetServices.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbDisableInternetServices.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="CbDisableInternetServices.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 17</value>
-  </data>
-  <data name="CbDisableInternetServices.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CbDisableInternetServices.Text" xml:space="preserve">
-    <value>Disable Internet services (not recommended)</value>
-  </data>
-  <data name="&gt;&gt;CbAutoSave.Name" xml:space="preserve">
-    <value>CbAutoSave</value>
-  </data>
-  <data name="&gt;&gt;CbAutoSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbAutoSave.Parent" xml:space="preserve">
-    <value>GroupSave</value>
-  </data>
-  <data name="&gt;&gt;CbAutoSave.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="GroupSave.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 81</value>
-  </data>
-  <data name="GroupSave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 42</value>
-  </data>
-  <data name="GroupSave.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="GroupSave.Text" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="CbAutoSave.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbAutoSave.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="CbAutoSave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>274, 17</value>
-  </data>
-  <data name="CbAutoSave.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CbAutoSave.Text" xml:space="preserve">
-    <value>Automatically save changes in your vocabulary book</value>
-  </data>
-  <data name="&gt;&gt;CbOptionalExpressions.Name" xml:space="preserve">
-    <value>CbOptionalExpressions</value>
-  </data>
-  <data name="&gt;&gt;CbOptionalExpressions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbOptionalExpressions.Parent" xml:space="preserve">
-    <value>GroupEvaluation</value>
-  </data>
-  <data name="&gt;&gt;CbOptionalExpressions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CbManualCheck.Name" xml:space="preserve">
-    <value>CbManualCheck</value>
-  </data>
-  <data name="&gt;&gt;CbManualCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbManualCheck.Parent" xml:space="preserve">
-    <value>GroupEvaluation</value>
-  </data>
-  <data name="&gt;&gt;CbManualCheck.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;CbShowPracticeResult.Name" xml:space="preserve">
-    <value>CbShowPracticeResult</value>
-  </data>
-  <data name="&gt;&gt;CbShowPracticeResult.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbShowPracticeResult.Parent" xml:space="preserve">
-    <value>GroupEvaluation</value>
-  </data>
-  <data name="&gt;&gt;CbShowPracticeResult.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="GroupEvaluation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 8</value>
-  </data>
-  <data name="GroupEvaluation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 88</value>
-  </data>
-  <data name="GroupEvaluation.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="GroupEvaluation.Text" xml:space="preserve">
-    <value>Evaluation</value>
-  </data>
-  <data name="CbOptionalExpressions.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbOptionalExpressions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbOptionalExpressions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 65</value>
-  </data>
-  <data name="CbOptionalExpressions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>235, 17</value>
-  </data>
-  <data name="CbOptionalExpressions.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="CbOptionalExpressions.Text" xml:space="preserve">
-    <value>Treat expressions in parantheses as optional</value>
-  </data>
-  <data name="CbManualCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbManualCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbManualCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="CbManualCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 17</value>
-  </data>
-  <data name="CbManualCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CbManualCheck.Text" xml:space="preserve">
-    <value>Self-evaluate translations when practicing</value>
-  </data>
-  <data name="CbShowPracticeResult.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbShowPracticeResult.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbShowPracticeResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="CbShowPracticeResult.Size" type="System.Drawing.Size, System.Drawing">
-    <value>159, 17</value>
-  </data>
-  <data name="CbShowPracticeResult.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CbShowPracticeResult.Text" xml:space="preserve">
-    <value>Show results after practicing</value>
-  </data>
-  <data name="&gt;&gt;CbAcousticFeedback.Name" xml:space="preserve">
-    <value>CbAcousticFeedback</value>
-  </data>
-  <data name="&gt;&gt;CbAcousticFeedback.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbAcousticFeedback.Parent" xml:space="preserve">
-    <value>GroupUserInterface</value>
-  </data>
-  <data name="&gt;&gt;CbAcousticFeedback.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CbSingleContinueButton.Name" xml:space="preserve">
-    <value>CbSingleContinueButton</value>
-  </data>
-  <data name="&gt;&gt;CbSingleContinueButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbSingleContinueButton.Parent" xml:space="preserve">
-    <value>GroupUserInterface</value>
-  </data>
-  <data name="&gt;&gt;CbSingleContinueButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GroupUserInterface.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 251</value>
-  </data>
-  <data name="GroupUserInterface.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 64</value>
-  </data>
-  <data name="GroupUserInterface.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="GroupUserInterface.Text" xml:space="preserve">
-    <value>User interface</value>
-  </data>
-  <data name="CbAcousticFeedback.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbAcousticFeedback.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="CbAcousticFeedback.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 17</value>
-  </data>
-  <data name="CbAcousticFeedback.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CbAcousticFeedback.Text" xml:space="preserve">
-    <value>Enable acoustic feedback</value>
-  </data>
-  <data name="CbSingleContinueButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbSingleContinueButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="CbSingleContinueButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 17</value>
-  </data>
-  <data name="CbSingleContinueButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CbSingleContinueButton.Text" xml:space="preserve">
-    <value>Press button only once after transalting</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateWhiteSpace.Name" xml:space="preserve">
-    <value>CbTolerateWhiteSpace</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateWhiteSpace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateWhiteSpace.Parent" xml:space="preserve">
-    <value>GroupNearlyCorrect</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateWhiteSpace.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateNoSynonym.Name" xml:space="preserve">
-    <value>CbTolerateNoSynonym</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateNoSynonym.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateNoSynonym.Parent" xml:space="preserve">
-    <value>GroupNearlyCorrect</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateNoSynonym.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateArticle.Name" xml:space="preserve">
-    <value>CbTolerateArticle</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateArticle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateArticle.Parent" xml:space="preserve">
-    <value>GroupNearlyCorrect</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateArticle.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;CbToleratePunctuationMark.Name" xml:space="preserve">
-    <value>CbToleratePunctuationMark</value>
-  </data>
-  <data name="&gt;&gt;CbToleratePunctuationMark.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbToleratePunctuationMark.Parent" xml:space="preserve">
-    <value>GroupNearlyCorrect</value>
-  </data>
-  <data name="&gt;&gt;CbToleratePunctuationMark.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateSpecialChar.Name" xml:space="preserve">
-    <value>CbTolerateSpecialChar</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateSpecialChar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateSpecialChar.Parent" xml:space="preserve">
-    <value>GroupNearlyCorrect</value>
-  </data>
-  <data name="&gt;&gt;CbTolerateSpecialChar.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="GroupNearlyCorrect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 107</value>
-  </data>
-  <data name="GroupNearlyCorrect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 133</value>
-  </data>
-  <data name="GroupNearlyCorrect.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="GroupNearlyCorrect.Text" xml:space="preserve">
-    <value>Mark as "Partly correct" when</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 17</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="CbTolerateWhiteSpace.Text" xml:space="preserve">
-    <value>whitespaces do not match</value>
-  </data>
-  <data name="CbTolerateNoSynonym.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbTolerateNoSynonym.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbTolerateNoSynonym.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 111</value>
-  </data>
-  <data name="CbTolerateNoSynonym.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 17</value>
-  </data>
-  <data name="CbTolerateNoSynonym.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="CbTolerateNoSynonym.Text" xml:space="preserve">
-    <value>only one of two synonyms is correct</value>
-  </data>
-  <data name="CbTolerateArticle.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbTolerateArticle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbTolerateArticle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 88</value>
-  </data>
-  <data name="CbTolerateArticle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>171, 17</value>
-  </data>
-  <data name="CbTolerateArticle.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="CbTolerateArticle.Text" xml:space="preserve">
-    <value>wrong articles have been used</value>
-  </data>
-  <data name="CbToleratePunctuationMark.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbToleratePunctuationMark.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbToleratePunctuationMark.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="CbToleratePunctuationMark.Size" type="System.Drawing.Size, System.Drawing">
-    <value>175, 17</value>
-  </data>
-  <data name="CbToleratePunctuationMark.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="CbToleratePunctuationMark.Text" xml:space="preserve">
-    <value>punctuation marks are incorrect</value>
-  </data>
-  <data name="CbTolerateSpecialChar.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CbTolerateSpecialChar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CbTolerateSpecialChar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 65</value>
-  </data>
-  <data name="CbTolerateSpecialChar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 17</value>
-  </data>
-  <data name="CbTolerateSpecialChar.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="CbTolerateSpecialChar.Text" xml:space="preserve">
-    <value>special chars are incorrect</value>
-  </data>
-  <data name="LbTrb6.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LbTrb6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>155, 35</value>
-  </data>
-  <data name="LbTrb6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="LbTrb6.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="LbTrb6.Text" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="LbTrb2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LbTrb2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 35</value>
-  </data>
-  <data name="LbTrb2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="LbTrb2.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="LbTrb2.Text" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="LbTrb5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LbTrb5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>119, 35</value>
-  </data>
-  <data name="LbTrb5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="LbTrb5.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="LbTrb5.Text" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="LbTrb3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LbTrb3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>45, 35</value>
-  </data>
-  <data name="LbTrb3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="LbTrb3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="LbTrb3.Text" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="LbTrb4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LbTrb4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>82, 35</value>
-  </data>
-  <data name="LbTrb4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="LbTrb4.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="LbTrb4.Text" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="TrbRepetitions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="TrbRepetitions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>172, 45</value>
-  </data>
-  <data name="TrbRepetitions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>319, 469</value>
+    <value>319, 489</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/src/Vocup.WinForms/Forms/SpecialCharKeyboard.Designer.cs
+++ b/src/Vocup.WinForms/Forms/SpecialCharKeyboard.Designer.cs
@@ -186,6 +186,7 @@
             // TpGerman
             // 
             TpGerman.AutoScroll = true;
+            TpGerman.BackColor = System.Drawing.SystemColors.Window;
             TpGerman.Controls.Add(doppel_s);
             TpGerman.Controls.Add(ue_big);
             TpGerman.Controls.Add(ae_big);
@@ -201,7 +202,6 @@
             TpGerman.TabIndex = 0;
             TpGerman.Tag = "de";
             TpGerman.Text = "German";
-            TpGerman.UseVisualStyleBackColor = true;
             // 
             // doppel_s
             // 
@@ -277,6 +277,7 @@
             // TpFrench
             // 
             TpFrench.AutoScroll = true;
+            TpFrench.BackColor = System.Drawing.SystemColors.Window;
             TpFrench.Controls.Add(û_big);
             TpFrench.Controls.Add(ÿ);
             TpFrench.Controls.Add(ÿ_big);
@@ -315,7 +316,6 @@
             TpFrench.TabIndex = 1;
             TpFrench.Tag = "fr";
             TpFrench.Text = "French";
-            TpFrench.UseVisualStyleBackColor = true;
             // 
             // û_big
             // 
@@ -620,6 +620,7 @@
             // TpItalian
             // 
             TpItalian.AutoScroll = true;
+            TpItalian.BackColor = System.Drawing.SystemColors.Window;
             TpItalian.Controls.Add(ú_big);
             TpItalian.Controls.Add(ù_it);
             TpItalian.Controls.Add(ù_it_big);
@@ -648,7 +649,6 @@
             TpItalian.TabIndex = 2;
             TpItalian.Tag = "it";
             TpItalian.Text = "Italian";
-            TpItalian.UseVisualStyleBackColor = true;
             // 
             // ú_big
             // 
@@ -854,6 +854,7 @@
             // TpSpanish
             // 
             TpSpanish.AutoScroll = true;
+            TpSpanish.BackColor = System.Drawing.SystemColors.Window;
             TpSpanish.Controls.Add(um_frag);
             TpSpanish.Controls.Add(umg_ausr);
             TpSpanish.Controls.Add(º);
@@ -880,7 +881,6 @@
             TpSpanish.TabIndex = 3;
             TpSpanish.Tag = "es";
             TpSpanish.Text = "Spanish";
-            TpSpanish.UseVisualStyleBackColor = true;
             // 
             // um_frag
             // 
@@ -1068,6 +1068,7 @@
             // TpRomanian
             // 
             TpRomanian.AutoScroll = true;
+            TpRomanian.BackColor = System.Drawing.SystemColors.Window;
             TpRomanian.Controls.Add(ţ_ro_big);
             TpRomanian.Controls.Add(ţ_ro);
             TpRomanian.Controls.Add(ş_ro_big);
@@ -1086,7 +1087,6 @@
             TpRomanian.TabIndex = 4;
             TpRomanian.Tag = "ro";
             TpRomanian.Text = "Romanian";
-            TpRomanian.UseVisualStyleBackColor = true;
             // 
             // ţ_ro_big
             // 
@@ -1200,6 +1200,7 @@
             // 
             // tpDutch
             // 
+            tpDutch.BackColor = System.Drawing.SystemColors.Window;
             tpDutch.Controls.Add(û_big_nl);
             tpDutch.Controls.Add(û_nl);
             tpDutch.Controls.Add(ü_big_nl);
@@ -1236,7 +1237,6 @@
             tpDutch.TabIndex = 5;
             tpDutch.Tag = "nl";
             tpDutch.Text = "Dutch";
-            tpDutch.UseVisualStyleBackColor = true;
             // 
             // û_big_nl
             // 

--- a/src/Vocup.WinForms/Forms/SpecialCharKeyboard.cs
+++ b/src/Vocup.WinForms/Forms/SpecialCharKeyboard.cs
@@ -93,7 +93,7 @@ public partial class SpecialCharKeyboard : Form
                         Tag = "Custom" + name,
                         Text = name,
                         AutoScroll = true,
-                        UseVisualStyleBackColor = true,
+                        BackColor = SystemColors.Window,
                         Font = new Font("Arial", 9.75f)
                     };
 

--- a/src/Vocup.WinForms/Forms/SpecialCharKeyboard.resx
+++ b/src/Vocup.WinForms/Forms/SpecialCharKeyboard.resx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/src/Vocup.WinForms/Forms/VocabularyBookSettings.cs
+++ b/src/Vocup.WinForms/Forms/VocabularyBookSettings.cs
@@ -12,7 +12,7 @@ namespace Vocup.Forms;
 public partial class VocabularyBookSettings : Form
 {
     private const string InvalidChars = "#=:\\/|<>*?\"";
-    private readonly Color redBgColor = Color.FromArgb(255, 192, 203);
+    private readonly Color InvalidInputBackColor;
     private readonly SpecialCharKeyboard specialCharDialog;
     private readonly VocabularyBook book;
 
@@ -22,6 +22,15 @@ public partial class VocabularyBookSettings : Form
         specialCharDialog = new SpecialCharKeyboard();
         specialCharDialog.Initialize(this, BtnSpecialChar);
         specialCharDialog.RegisterTextBox(TbMotherTongue);
+
+        InvalidInputBackColor = Color.FromArgb(255, 192, 203);
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (Application.ColorMode == SystemColorMode.Dark)
+        {
+            InvalidInputBackColor = Color.FromArgb(127, 0, 0);
+        }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     public VocabularyBookSettings(out VocabularyBook book) : this()
@@ -57,9 +66,9 @@ public partial class VocabularyBookSettings : Form
     private void TextBox_TextChanged(object sender, EventArgs e)
     {
         bool mValid = !TbMotherTongue.Text.ContainsAny(InvalidChars);
-        TbMotherTongue.BackColor = mValid ? Color.White : redBgColor;
+        TbMotherTongue.BackColor = mValid ? SystemColors.Window : InvalidInputBackColor;
         bool fValid = !TbForeignLang.Text.ContainsAny(InvalidChars);
-        TbForeignLang.BackColor = fValid ? Color.White : redBgColor;
+        TbForeignLang.BackColor = fValid ? SystemColors.Window : InvalidInputBackColor;
 
         if (mValid && fValid &&
             !string.IsNullOrWhiteSpace(TbMotherTongue.Text) &&

--- a/src/Vocup.WinForms/Forms/VocabularyWordDialog.cs
+++ b/src/Vocup.WinForms/Forms/VocabularyWordDialog.cs
@@ -38,9 +38,9 @@ namespace Vocup.Forms
                 !TbForeignLangSynonym.Text.ContainsAny(InvalidChars);
 
             // Visual feedback for invalid chars.
-            TbMotherTongue.BackColor = TbMotherTongue.Text.ContainsAny(InvalidChars) ? redBgColor : Color.White;
-            TbForeignLang.BackColor = TbForeignLang.Text.ContainsAny(InvalidChars) ? redBgColor : Color.White;
-            TbForeignLangSynonym.BackColor = TbForeignLangSynonym.Text.ContainsAny(InvalidChars) ? redBgColor : Color.White;
+            TbMotherTongue.BackColor = TbMotherTongue.Text.ContainsAny(InvalidChars) ? redBgColor : SystemColors.Window;
+            TbForeignLang.BackColor = TbForeignLang.Text.ContainsAny(InvalidChars) ? redBgColor : SystemColors.Window;
+            TbForeignLangSynonym.BackColor = TbForeignLangSynonym.Text.ContainsAny(InvalidChars) ? redBgColor : SystemColors.Window;
 
             OnInputValidated(BtnContinue.Enabled);
         }

--- a/src/Vocup.WinForms/Forms/VocabularyWordDialog.cs
+++ b/src/Vocup.WinForms/Forms/VocabularyWordDialog.cs
@@ -10,7 +10,7 @@ namespace Vocup.Forms
     public partial class VocabularyWordDialog : Form
     {
         private const string InvalidChars = "#=";
-        private readonly Color redBgColor = Color.FromArgb(255, 192, 203);
+        private readonly Color InvalidInputBackColor;
         private readonly SpecialCharKeyboard specialCharDialog;
         protected readonly VocabularyBook book;
 
@@ -20,6 +20,15 @@ namespace Vocup.Forms
 
             specialCharDialog = new SpecialCharKeyboard();
             specialCharDialog.Initialize(this, BtnSpecialChar);
+
+            InvalidInputBackColor = Color.FromArgb(255, 192, 203);
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            if (Application.ColorMode == SystemColorMode.Dark)
+            {
+                InvalidInputBackColor = Color.FromArgb(127, 0, 0);
+            }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             this.book = book;
             LbMotherTongue.Text = book.MotherTongue;
@@ -38,9 +47,9 @@ namespace Vocup.Forms
                 !TbForeignLangSynonym.Text.ContainsAny(InvalidChars);
 
             // Visual feedback for invalid chars.
-            TbMotherTongue.BackColor = TbMotherTongue.Text.ContainsAny(InvalidChars) ? redBgColor : SystemColors.Window;
-            TbForeignLang.BackColor = TbForeignLang.Text.ContainsAny(InvalidChars) ? redBgColor : SystemColors.Window;
-            TbForeignLangSynonym.BackColor = TbForeignLangSynonym.Text.ContainsAny(InvalidChars) ? redBgColor : SystemColors.Window;
+            TbMotherTongue.BackColor = TbMotherTongue.Text.ContainsAny(InvalidChars) ? InvalidInputBackColor : SystemColors.Window;
+            TbForeignLang.BackColor = TbForeignLang.Text.ContainsAny(InvalidChars) ? InvalidInputBackColor : SystemColors.Window;
+            TbForeignLangSynonym.BackColor = TbForeignLangSynonym.Text.ContainsAny(InvalidChars) ? InvalidInputBackColor : SystemColors.Window;
 
             OnInputValidated(BtnContinue.Enabled);
         }

--- a/src/Vocup.WinForms/MainForm.cs
+++ b/src/Vocup.WinForms/MainForm.cs
@@ -550,14 +550,13 @@ public partial class MainForm : Form, IMainForm
                 lastSearchResult = index;
             }
 
-            Color @default = Color.White;
             Color highlight = index == -1 ? Color.FromArgb(255, 192, 203) : Color.FromArgb(144, 238, 144);
 
             TbSearchWord.BackColor = highlight;
 
             await Task.Delay(500);
 
-            TbSearchWord.BackColor = @default;
+            TbSearchWord.BackColor = SystemColors.Window;
         }
     }
 
@@ -764,27 +763,27 @@ public partial class MainForm : Form, IMainForm
     {
         using PracticeCountDialog countDialog = new(CurrentBook);
 
-            if (countDialog.ShowDialog() == DialogResult.OK)
-            {
-                List<VocabularyWordPractice> practiceList = countDialog.PracticeList;
+        if (countDialog.ShowDialog() == DialogResult.OK)
+        {
+            List<VocabularyWordPractice> practiceList = countDialog.PracticeList;
 
-                CurrentController.ListView.Visible = false;
+            CurrentController.ListView.Visible = false;
 
             using (var dialog = new PracticeDialog(CurrentBook, practiceList) { Owner = this })
                 dialog.ShowDialog();
 
-                if (Program.Settings.PracticeShowResultList)
-                {
+            if (Program.Settings.PracticeShowResultList)
+            {
                 using PracticeResultList dialog = new(CurrentBook, practiceList);
                 dialog.ShowDialog();
-                }
-
-                CurrentController.ListView.Visible = true;
-                BtnAddWord.Focus();
             }
 
-            Program.TrackingService.Page("/book");
+            CurrentController.ListView.Visible = true;
+            BtnAddWord.Focus();
         }
+
+        Program.TrackingService.Page("/book");
+    }
 
     private static void EvaluationInfo()
     {

--- a/src/Vocup.WinForms/Program.cs
+++ b/src/Vocup.WinForms/Program.cs
@@ -60,7 +60,7 @@ public static class Program
         SetCulture();
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        Application.SetColorMode(SystemColorMode.Dark);
+        Application.SetColorMode(Settings.ColorMode);
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         if (!CreateVhfFolder() || !CreateVhrFolder())

--- a/src/Vocup.WinForms/Program.cs
+++ b/src/Vocup.WinForms/Program.cs
@@ -53,8 +53,6 @@ public static class Program
         splash.Show();
         Application.DoEvents();
 
-        AppBuilder.Configure<App>().UsePlatformDetect().UseReactiveUI().SetupWithoutStarting();
-
         var serviceScope = InitializeServices();
 
         SetCulture();
@@ -62,6 +60,8 @@ public static class Program
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         Application.SetColorMode(Settings.ColorMode);
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+        AppBuilder.Configure<Util.App>().UsePlatformDetect().UseReactiveUI().SetupWithoutStarting();
 
         if (!CreateVhfFolder() || !CreateVhrFolder())
         {

--- a/src/Vocup.WinForms/Program.cs
+++ b/src/Vocup.WinForms/Program.cs
@@ -58,6 +58,11 @@ public static class Program
         var serviceScope = InitializeServices();
 
         SetCulture();
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        Application.SetColorMode(SystemColorMode.Dark);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         if (!CreateVhfFolder() || !CreateVhrFolder())
         {
             Application.Exit();

--- a/src/Vocup.WinForms/Settings/VocupSettings.cs
+++ b/src/Vocup.WinForms/Settings/VocupSettings.cs
@@ -24,6 +24,7 @@ public class VocupSettings : SettingsBase, ICopyable<VocupSettings>
             _vhrPath = _vhrPath,
             _startupCounter = _startupCounter,
             _columnResize = _columnResize,
+            _colorMode = _colorMode,
             _overrideCulture = _overrideCulture,
             _practicePercentageUnpracticed = _practicePercentageUnpracticed,
             _practicePercentageCorrect = _practicePercentageCorrect,
@@ -127,6 +128,16 @@ public class VocupSettings : SettingsBase, ICopyable<VocupSettings>
         get => _columnResize;
         set => RaiseAndSetIfChanged(ref _columnResize, value);
     }
+
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private SystemColorMode _colorMode = SystemColorMode.System;
+    public SystemColorMode ColorMode
+    {
+        get => _colorMode;
+        set => RaiseAndSetIfChanged(ref _colorMode, value);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 
     private string? _overrideCulture;

--- a/src/Vocup.WinForms/Util/App.cs
+++ b/src/Vocup.WinForms/Util/App.cs
@@ -1,0 +1,19 @@
+﻿using System.Windows.Forms;
+
+namespace Vocup.Util;
+
+public partial class App : Vocup.App
+{
+    public override void OnFrameworkInitializationCompleted()
+    {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        RequestedThemeVariant = Application.ColorMode switch
+        {
+            SystemColorMode.Dark => Avalonia.Styling.ThemeVariant.Dark,
+            _ => Avalonia.Styling.ThemeVariant.Light,
+        };
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}


### PR DESCRIPTION
This pull request enables the experimental dark mode from .NET 9 for Windows Forms and applies the same color mode for the Avalonia-based about view. Vocup will match the OS color theme by default but this pull request also adds an option to override the color mode.

I consider it acceptable to use an experimental feature in a release version of Vocup because a dark mode is not an essential feature that would render the application unusable in case it should break with the release of .NET 10. Instead, the dark mode could be removed again if it should cause issues.

It would be preferable to create a new settings versions because older versions of Vocup will reset the color mode setting if used as a custom build on the same computer. For Microsoft Store distribution only one version can be installed at once.